### PR TITLE
Remove useless await

### DIFF
--- a/RClick/MenuBarView.swift
+++ b/RClick/MenuBarView.swift
@@ -35,7 +35,7 @@ struct MenuBarView: View {
       
         Task {
             try await Task.sleep(nanoseconds:UInt64(1.0 * 1e9))
-            await NSApplication.shared.terminate(self)
+            NSApplication.shared.terminate(self)
         }
     }
 


### PR DESCRIPTION
`NSApplication.shared.terminate` is not an asynchronous function