### PR TITLE
Add trilingual localization support

### DIFF
--- a/FinderSyncExt/FinderSyncExt.swift
+++ b/FinderSyncExt/FinderSyncExt.swift
@@ -259,7 +259,7 @@ class FinderSyncExt: FIFinderSync, @unchecked Sendable {
         // 如果缓存为空，触发请求并返回加载中的菜单
         guard let config = cachedMenuConfig else {
             requestMenuConfig()
-            menu.addItem(withTitle: String(localized: "RClick (loading...)"), action: nil, keyEquivalent: "")
+            menu.addItem(withTitle: AppLocalization.localized("RClick (loading...)"), action: nil, keyEquivalent: "")
             return menu
         }
 
@@ -267,7 +267,8 @@ class FinderSyncExt: FIFinderSync, @unchecked Sendable {
         if !config.actions.isEmpty {
             if config.actionsCollapsed {
                 // 折叠：使用子菜单
-                let actionsSubMenu = NSMenu(title: "操作")
+                let actionsTitle = AppLocalization.localized("Actions")
+                let actionsSubMenu = NSMenu(title: actionsTitle)
                 for action in config.actions {
                     let item = NSMenuItem(title: action.name, action: #selector(handleActionClick(_:)), keyEquivalent: "")
                     item.tag = hashForAction(action)
@@ -277,7 +278,7 @@ class FinderSyncExt: FIFinderSync, @unchecked Sendable {
                     }
                     actionsSubMenu.addItem(item)
                 }
-                let actionsItem = NSMenuItem(title: "操作", action: nil, keyEquivalent: "")
+                let actionsItem = NSMenuItem(title: actionsTitle, action: nil, keyEquivalent: "")
                 actionsItem.submenu = actionsSubMenu
                 menu.addItem(actionsItem)
             } else {
@@ -298,7 +299,8 @@ class FinderSyncExt: FIFinderSync, @unchecked Sendable {
         if !config.apps.isEmpty {
             if config.appsCollapsed {
                 // 折叠：使用子菜单
-                let appsSubMenu = NSMenu(title: "打开方式")
+                let appsTitle = AppLocalization.localized("Open With")
+                let appsSubMenu = NSMenu(title: appsTitle)
                 for app in config.apps {
                     let item = NSMenuItem(title: app.name, action: #selector(handleAppClick(_:)), keyEquivalent: "")
                     item.tag = hashForApp(app)
@@ -306,7 +308,7 @@ class FinderSyncExt: FIFinderSync, @unchecked Sendable {
                     item.image = cachedAppIcon(app: app)
                     appsSubMenu.addItem(item)
                 }
-                let appsItem = NSMenuItem(title: "打开方式", action: nil, keyEquivalent: "")
+                let appsItem = NSMenuItem(title: appsTitle, action: nil, keyEquivalent: "")
                 appsItem.submenu = appsSubMenu
                 menu.addItem(appsItem)
             } else {
@@ -325,7 +327,8 @@ class FinderSyncExt: FIFinderSync, @unchecked Sendable {
         if !config.newFiles.isEmpty {
             if config.newFilesCollapsed {
                 // 折叠：使用子菜单
-                let newFilesSubMenu = NSMenu(title: "新建文件")
+                let newFilesTitle = AppLocalization.localized("New File")
+                let newFilesSubMenu = NSMenu(title: newFilesTitle)
                 for newFile in config.newFiles {
                     let item = NSMenuItem(title: newFile.name, action: #selector(handleNewFileClick(_:)), keyEquivalent: "")
                     item.tag = hashForNewFile(newFile)
@@ -334,7 +337,7 @@ class FinderSyncExt: FIFinderSync, @unchecked Sendable {
                     item.image?.accessibilityDescription = newFile.name
                     newFilesSubMenu.addItem(item)
                 }
-                let newFilesItem = NSMenuItem(title: "新建文件", action: nil, keyEquivalent: "")
+                let newFilesItem = NSMenuItem(title: newFilesTitle, action: nil, keyEquivalent: "")
                 newFilesItem.submenu = newFilesSubMenu
                 newFilesItem.image = templateSymbol("doc.badge.plus")
                 menu.addItem(newFilesItem)
@@ -355,7 +358,8 @@ class FinderSyncExt: FIFinderSync, @unchecked Sendable {
         if !config.commonDirs.isEmpty {
             if config.commonDirsCollapsed {
                 // 折叠：使用子菜单
-                let commonDirsSubMenu = NSMenu(title: "常用文件夹")
+                let commonDirsTitle = AppLocalization.localized("Common Dirs")
+                let commonDirsSubMenu = NSMenu(title: commonDirsTitle)
                 for commonDir in config.commonDirs {
                     let item = NSMenuItem(title: commonDir.name, action: #selector(handleCommonDirClick(_:)), keyEquivalent: "")
                     item.tag = hashForCommonDir(commonDir)
@@ -363,7 +367,7 @@ class FinderSyncExt: FIFinderSync, @unchecked Sendable {
                     item.image = loadIcon(named: commonDir.icon, accessibilityDescription: commonDir.name)
                     commonDirsSubMenu.addItem(item)
                 }
-                let commonDirsItem = NSMenuItem(title: "常用文件夹", action: nil, keyEquivalent: "")
+                let commonDirsItem = NSMenuItem(title: commonDirsTitle, action: nil, keyEquivalent: "")
                 commonDirsItem.submenu = commonDirsSubMenu
                 commonDirsItem.image = templateSymbol("folder")
                 menu.addItem(commonDirsItem)
@@ -532,4 +536,3 @@ extension NSMenu {
         self.addItem(sectionHeader)
     }
 }
-

--- a/FinderSyncExt/Localizable.xcstrings
+++ b/FinderSyncExt/Localizable.xcstrings
@@ -1,106 +1,3264 @@
 {
-  "sourceLanguage" : "en",
-  "strings" : {
-    "Actions" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Actions"
+  "sourceLanguage": "en",
+  "strings": {
+    "Actions": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Actions"
           }
         },
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "操作"
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "操作"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "操作"
           }
         }
       }
     },
-    "AirDrop" : {
-
-    },
-    "Common Dirs" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Common Dirs"
+    "AirDrop": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "AirDrop"
           }
         },
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "常用文件夹"
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "AirDrop"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "AirDrop"
           }
         }
       }
     },
-    "Copy Path" : {
-
-    },
-    "Delete Direct" : {
-
-    },
-    "Hide" : {
-
-    },
-    "New File" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "New File"
+    "Common Dirs": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Common Folders"
           }
         },
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "新建文件"
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "常用文件夹"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "よく使うフォルダ"
           }
         }
       }
     },
-    "Open With" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Open With"
+    "Copy Path": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Copy Path"
           }
         },
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "用...打开"
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "复制路径"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "パスをコピー"
           }
         }
       }
     },
-    "RClick (loading...)" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "RClick (loading...)"
+    "Delete Direct": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Delete Direct"
           }
         },
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "RClick (加载中...)"
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "直接删除"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "直接削除"
           }
         }
       }
     },
-    "Unhide" : {
-
+    "Hide": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Hide"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "隐藏"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "隠す"
+          }
+        }
+      }
+    },
+    "New File": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "New File"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "新建文件"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "新規ファイル"
+          }
+        }
+      }
+    },
+    "Open With": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Open With"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "用...打开"
+          }
+        }
+      }
+    },
+    "RClick (loading...)": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "RClick (loading...)"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "RClick（加载中...）"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "RClick（読み込み中...）"
+          }
+        }
+      }
+    },
+    "Unhide": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Unhide"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "显示"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "再表示"
+          }
+        }
+      }
+    },
+    "1. Click \"Settings…\" on the right to open System Settings": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "1. Click \"Settings…\" on the right to open System Settings"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "1. 点击右侧“设置…”按钮打开系统设置"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "1. 右側の「設定…」をクリックしてシステム設定を開きます"
+          }
+        }
+      }
+    },
+    "2. Click the lock icon and authenticate": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "2. Click the lock icon and authenticate"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "2. 点击左下角锁图标并认证"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "2. 左下の鍵アイコンをクリックして認証します"
+          }
+        }
+      }
+    },
+    "3. Click \"+\" -> open \"Applications\" -> select \"RClick\"": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "3. Click \"+\" -> open \"Applications\" -> select \"RClick\""
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "3. 点击“+”并前往“应用程序”，选择“RClick”"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "3. 「+」を押して「アプリケーション」から「RClick」を選択します"
+          }
+        }
+      }
+    },
+    "4. Make sure the switch next to RClick is turned on": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "4. Make sure the switch next to RClick is turned on"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "4. 确保 RClick 旁边的开关已打开"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "4. RClick の横にあるスイッチがオンになっていることを確認します"
+          }
+        }
+      }
+    },
+    "About": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "About"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "关于"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "情報"
+          }
+        }
+      }
+    },
+    "Accessibility": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Accessibility"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "辅助功能"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "アクセシビリティ"
+          }
+        }
+      }
+    },
+    "Add": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Add"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "添加"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "追加"
+          }
+        }
+      }
+    },
+    "Add App": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Add App"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "添加应用"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "アプリを追加"
+          }
+        }
+      }
+    },
+    "Add File Type": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Add File Type"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "添加文件类型"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "ファイル種類を追加"
+          }
+        }
+      }
+    },
+    "Add Folder": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Add Folder"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "添加文件夹"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "フォルダを追加"
+          }
+        }
+      }
+    },
+    "Added Folders": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Added Folders"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "已添加的文件夹"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "追加済みフォルダ"
+          }
+        }
+      }
+    },
+    "Applications": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Applications"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "应用程序"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "アプリケーション"
+          }
+        }
+      }
+    },
+    "Apps": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Apps"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "应用"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "アプリ"
+          }
+        }
+      }
+    },
+    "Arguments (semicolon separated)": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Arguments (semicolon separated)"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "参数（分号分隔）"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "引数（セミコロン区切り）"
+          }
+        }
+      }
+    },
+    "Arguments: %@": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Arguments: %@"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "参数：%@"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "引数: %@"
+          }
+        }
+      }
+    },
+    "Authorized": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Authorized"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "已授权"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "許可済み"
+          }
+        }
+      }
+    },
+    "Automatic": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Automatic"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "自动"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "自動"
+          }
+        }
+      }
+    },
+    "Backup": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Backup"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "备份"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "バックアップ"
+          }
+        }
+      }
+    },
+    "Cancel": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Cancel"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "取消"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "キャンセル"
+          }
+        }
+      }
+    },
+    "Change App": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Change App"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "更换应用"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "アプリを変更"
+          }
+        }
+      }
+    },
+    "Change Template": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Change Template"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "更换模板"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "テンプレートを変更"
+          }
+        }
+      }
+    },
+    "Check for Updates": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Check for Updates"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "检查更新"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "アップデートを確認"
+          }
+        }
+      }
+    },
+    "Checking for updates...": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Checking for updates..."
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "正在检查更新..."
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "アップデートを確認中..."
+          }
+        }
+      }
+    },
+    "Choose Default App": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Choose Default App"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "选择默认打开应用"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "既定アプリを選択"
+          }
+        }
+      }
+    },
+    "Choose Template File": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Choose Template File"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "选择模板文件"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "テンプレートファイルを選択"
+          }
+        }
+      }
+    },
+    "Collapse actions menu": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Collapse actions menu"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "折叠动作菜单"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "操作メニューを折りたたむ"
+          }
+        }
+      }
+    },
+    "Collapse apps menu": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Collapse apps menu"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "折叠应用菜单"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "アプリメニューを折りたたむ"
+          }
+        }
+      }
+    },
+    "Collapse menu": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Collapse menu"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "折叠菜单"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "メニューを折りたたむ"
+          }
+        }
+      }
+    },
+    "Collapse new file menu": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Collapse new file menu"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "折叠新建文件菜单"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "新規ファイルメニューを折りたたむ"
+          }
+        }
+      }
+    },
+    "Common Dir": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Common Folders"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "常用文件夹"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "よく使うフォルダ"
+          }
+        }
+      }
+    },
+    "Default Open App": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Default Open App"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "默认打开应用"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "既定で開くアプリ"
+          }
+        }
+      }
+    },
+    "Delete App": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Delete App"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "删除应用"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "アプリを削除"
+          }
+        }
+      }
+    },
+    "Desktop": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Desktop"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "桌面"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "デスクトップ"
+          }
+        }
+      }
+    },
+    "Display Name": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Display Name"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "显示名称"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "表示名"
+          }
+        }
+      }
+    },
+    "Documents": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Documents"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "文档"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "書類"
+          }
+        }
+      }
+    },
+    "Don't Ask Again": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Don't Ask Again"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "不再询问"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "今後表示しない"
+          }
+        }
+      }
+    },
+    "Download Manually": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Download Manually"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "手动下载"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "手動でダウンロード"
+          }
+        }
+      }
+    },
+    "Download and Install": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Download and Install"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "下载并安装"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "ダウンロードしてインストール"
+          }
+        }
+      }
+    },
+    "Downloads": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Downloads"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "下载"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "ダウンロード"
+          }
+        }
+      }
+    },
+    "Edit App": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Edit App"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "编辑应用"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "アプリを編集"
+          }
+        }
+      }
+    },
+    "Edit App Properties": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Edit App Properties"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "编辑应用属性"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "アプリ設定を編集"
+          }
+        }
+      }
+    },
+    "Edit File Type": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Edit File Type"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "编辑文件类型"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "ファイル種類を編集"
+          }
+        }
+      }
+    },
+    "Enable Full Disk Access": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Enable Full Disk Access"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "启用完全磁盘访问权限"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "フルディスクアクセスを有効にする"
+          }
+        }
+      }
+    },
+    "Enable RClick": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Enable RClick"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "启用 RClick"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "RClick を有効にする"
+          }
+        }
+      }
+    },
+    "Enable RClick in File Provider to show its actions in Finder context menus": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Enable RClick in File Provider to show its actions in Finder context menus"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "在文件提供程序中启用 RClick 以在 Finder 右键菜单中显示功能"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "ファイルプロバイダで RClick を有効にすると Finder の右クリックメニューに表示されます"
+          }
+        }
+      }
+    },
+    "Enable common folders": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Enable common folders"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "启用常用文件夹"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "よく使うフォルダを有効化"
+          }
+        }
+      }
+    },
+    "Enabled": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Enabled"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "启用"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "有効"
+          }
+        }
+      }
+    },
+    "English": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "English"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "English"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "English"
+          }
+        }
+      }
+    },
+    "Enter an SF Symbol name, for example doc.text or curlybraces": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Enter an SF Symbol name, for example doc.text or curlybraces"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "输入 SF Symbol 名称，例如 doc.text、curlybraces"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "SF Symbol 名を入力してください。例: doc.text、curlybraces"
+          }
+        }
+      }
+    },
+    "Environment Variables": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Environment Variables"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "环境变量"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "環境変数"
+          }
+        }
+      }
+    },
+    "Environment variables: %lld": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Environment variables: %lld"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "环境变量：%lld 个"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "環境変数: %lld 個"
+          }
+        }
+      }
+    },
+    "Export Logs…": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Export Logs…"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "导出日志…"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "ログを書き出し…"
+          }
+        }
+      }
+    },
+    "Export…": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Export…"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "导出…"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "書き出し…"
+          }
+        }
+      }
+    },
+    "Extension: %@": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Extension: %@"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "扩展名：%@"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "拡張子: %@"
+          }
+        }
+      }
+    },
+    "Extraction failed: %@": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Extraction failed: %@"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "解压失败：%@"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "展開に失敗しました: %@"
+          }
+        }
+      }
+    },
+    "Failed to Check for Updates": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Failed to Check for Updates"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "检查更新失败"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "アップデートの確認に失敗しました"
+          }
+        }
+      }
+    },
+    "File Extension": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "File Extension"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "文件扩展名"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "ファイル拡張子"
+          }
+        }
+      }
+    },
+    "File Provider: Select \"RClick\" in the list to enable the Finder context menu": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "File Provider: Select \"RClick\" in the list to enable the Finder context menu"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "文件提供程序：在列表中选择“RClick”以启用 Finder 右键菜单"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "ファイルプロバイダ一覧で「RClick」を選択すると Finder の右クリックメニューを有効にできます"
+          }
+        }
+      }
+    },
+    "Finder Extension": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Finder Extension"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Finder 扩展"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Finder 拡張"
+          }
+        }
+      }
+    },
+    "Folder access permission is required to use this feature.": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Folder access permission is required to use this feature."
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "必须授予文件夹访问权限才能使用此功能。"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "この機能を使うにはフォルダへのアクセス許可が必要です。"
+          }
+        }
+      }
+    },
+    "Folders cannot be shared via AirDrop: %@": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Folders cannot be shared via AirDrop: %@"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "不能通过 AirDrop 分享文件夹：%@"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "フォルダは AirDrop で共有できません: %@"
+          }
+        }
+      }
+    },
+    "For example: txt, md, json": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "For example: txt, md, json"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "例如：txt、md、json"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "例: txt、md、json"
+          }
+        }
+      }
+    },
+    "Format: KEY=VALUE, one per line": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Format: KEY=VALUE, one per line"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "格式：KEY=VALUE，每行一个"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "形式: KEY=VALUE を1行ずつ入力"
+          }
+        }
+      }
+    },
+    "Full Disk Access": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Full Disk Access"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "完全磁盘访问权限"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "フルディスクアクセス"
+          }
+        }
+      }
+    },
+    "Full Disk Access: Required to create and delete files in protected directories": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Full Disk Access: Required to create and delete files in protected directories"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "完全磁盘访问权限：用于在受保护目录中创建和删除文件"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "フルディスクアクセスは保護されたディレクトリでのファイル作成と削除に必要です"
+          }
+        }
+      }
+    },
+    "General": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "General"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "通用"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "一般"
+          }
+        }
+      }
+    },
+    "Grant Permission": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Grant Permission"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "授予权限"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "権限を付与"
+          }
+        }
+      }
+    },
+    "Home": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Home"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "用户主目录"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "ホーム"
+          }
+        }
+      }
+    },
+    "Icon": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Icon"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "图标"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "アイコン"
+          }
+        }
+      }
+    },
+    "Ignore This Version": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Ignore This Version"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "忽略此版本"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "このバージョンを無視"
+          }
+        }
+      }
+    },
+    "Import…": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Import…"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "导入…"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "読み込み…"
+          }
+        }
+      }
+    },
+    "Installation failed: %@": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Installation failed: %@"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "安装失败：%@"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "インストールに失敗しました: %@"
+          }
+        }
+      }
+    },
+    "Invalid Folder": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Invalid Folder"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "无效文件夹"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "無効なフォルダ"
+          }
+        }
+      }
+    },
+    "Japanese": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Japanese"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "日本語"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "日本語"
+          }
+        }
+      }
+    },
+    "Language": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Language"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "语言"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "言語"
+          }
+        }
+      }
+    },
+    "Later": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Later"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "稍后"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "あとで"
+          }
+        }
+      }
+    },
+    "Launch at login": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Launch at login"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "登录时启动"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "ログイン時に起動"
+          }
+        }
+      }
+    },
+    "Logs": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Logs"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "日志"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "ログ"
+          }
+        }
+      }
+    },
+    "Main Controls": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Main Controls"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "主要控制"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "メイン設定"
+          }
+        }
+      }
+    },
+    "Name": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Name"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "名称"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "名称"
+          }
+        }
+      }
+    },
+    "New Version Available": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "New Version Available"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "发现新版本"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "新しいバージョンがあります"
+          }
+        }
+      }
+    },
+    "No .app application was found in the ZIP file.": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "No .app application was found in the ZIP file."
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "在 ZIP 文件中未找到 .app 应用程序。"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "ZIP ファイル内に .app アプリケーションが見つかりません。"
+          }
+        }
+      }
+    },
+    "No .app.zip application package was found.": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "No .app.zip application package was found."
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "未找到 .app.zip 格式的应用程序包。"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": ".app.zip 形式のアプリケーションパッケージが見つかりません。"
+          }
+        }
+      }
+    },
+    "No update is available.": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "No update is available."
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "没有可用的更新。"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "利用可能なアップデートはありません。"
+          }
+        }
+      }
+    },
+    "Not Authorized": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Not Authorized"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "未授权"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "未許可"
+          }
+        }
+      }
+    },
+    "Notice": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Notice"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "提示"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "お知らせ"
+          }
+        }
+      }
+    },
+    "OK": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "OK"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "确定"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "OK"
+          }
+        }
+      }
+    },
+    "Open Settings": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Open Settings"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "打开设置"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "設定を開く"
+          }
+        }
+      }
+    },
+    "Permissions": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Permissions"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "权限"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "権限"
+          }
+        }
+      }
+    },
+    "Please select the correct Applications folder.": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Please select the correct Applications folder."
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "请选择正确的“应用程序”文件夹。"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "正しいアプリケーションフォルダを選択してください。"
+          }
+        }
+      }
+    },
+    "Preview:": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Preview:"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "预览："
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "プレビュー:"
+          }
+        }
+      }
+    },
+    "Protected system folders cannot be deleted: %@": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Protected system folders cannot be deleted: %@"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "无法删除系统保护文件夹：%@"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "保護されたシステムフォルダは削除できません: %@"
+          }
+        }
+      }
+    },
+    "Protected system folders cannot be shared: %@": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Protected system folders cannot be shared: %@"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "无法分享系统保护文件夹：%@"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "保護されたシステムフォルダは共有できません: %@"
+          }
+        }
+      }
+    },
+    "Quit": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Quit"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "退出"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "終了"
+          }
+        }
+      }
+    },
+    "RClick is a right-click menu extension that allows you to add applications for opening folders and includes some common actions.": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "RClick is a right-click menu extension that allows you to add applications for opening folders and includes some common actions."
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "RClick 是一个右键菜单扩展，可以添加打开文件夹的应用，并提供一些常用操作。"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "RClick はフォルダを開くアプリを追加できる右クリックメニュー拡張で、いくつかの便利な操作も含まれています。"
+          }
+        }
+      }
+    },
+    "RClick needs Full Disk Access to create files, delete files, and manage hidden files in protected folders (like Desktop, Documents, and Downloads).\n\nWithout this permission, some operations may fail on protected directories.\n\nTo enable:\n1. Click \"Open Settings\" below\n2. Click the lock icon and authenticate\n3. Click \"+\" and add RClick from your Applications folder\n4. Toggle the switch next to RClick to ON": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "RClick needs Full Disk Access to create files, delete files, and manage hidden files in protected folders (like Desktop, Documents, and Downloads).\n\nWithout this permission, some operations may fail on protected directories.\n\nTo enable:\n1. Click \"Open Settings\" below\n2. Click the lock icon and authenticate\n3. Click \"+\" and add RClick from your Applications folder\n4. Toggle the switch next to RClick to ON"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "RClick 需要完全磁盘访问权限，才能在受保护文件夹中创建文件、删除文件和管理隐藏文件，例如桌面、文稿和下载。\n\n没有此权限时，某些操作可能会在受保护目录中失败。\n\n启用方法：\n1. 点击下方“打开设置”\n2. 点击锁图标并认证\n3. 点击“+”，从“应用程序”文件夹添加 RClick\n4. 打开 RClick 旁边的开关"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "RClick がデスクトップ、書類、ダウンロードなどの保護されたフォルダでファイルの作成、削除、隠しファイルの管理を行うには、フルディスクアクセスが必要です。\n\nこの権限がない場合、保護されたディレクトリで一部の操作が失敗することがあります。\n\n有効にするには:\n1. 下の「設定を開く」をクリックします\n2. 鍵アイコンをクリックして認証します\n3. 「+」をクリックし、アプリケーションフォルダから RClick を追加します\n4. RClick の横にあるスイッチをオンにします"
+          }
+        }
+      }
+    },
+    "RClick needs Full Disk Access to work with files in protected directories": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "RClick needs Full Disk Access to work with files in protected directories"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "RClick 需要完全磁盘访问权限才能正常操作受保护目录中的文件"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "RClick が保護されたディレクトリ内のファイルを操作するにはフルディスクアクセスが必要です"
+          }
+        }
+      }
+    },
+    "RClick needs permission to install the update into your Applications folder.": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "RClick needs permission to install the update into your Applications folder."
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "RClick 需要权限以将更新安装到您的“应用程序”文件夹中。"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "RClick がアップデートをアプリケーションフォルダにインストールするには権限が必要です。"
+          }
+        }
+      }
+    },
+    "Reset": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Reset"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "重置"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "リセット"
+          }
+        }
+      }
+    },
+    "Reset All Settings?": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Reset All Settings?"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "重置所有设置？"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "すべての設定をリセットしますか？"
+          }
+        }
+      }
+    },
+    "Reset All Settings…": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Reset All Settings…"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "重置所有设置…"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "すべての設定をリセット…"
+          }
+        }
+      }
+    },
+    "Resetting all settings restores the default configuration and cannot be undone": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Resetting all settings restores the default configuration and cannot be undone"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "重置所有设置将恢复默认配置，此操作不可逆"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "すべての設定をリセットすると既定値に戻り、この操作は元に戻せません"
+          }
+        }
+      }
+    },
+    "Restart Later": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Restart Later"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "稍后重启"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "あとで再起動"
+          }
+        }
+      }
+    },
+    "Restart Now": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Restart Now"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "立即重启"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "今すぐ再起動"
+          }
+        }
+      }
+    },
+    "Restore Defaults": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Restore Defaults"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "恢复默认"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "デフォルトに戻す"
+          }
+        }
+      }
+    },
+    "Run Arguments": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Run Arguments"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "运行参数"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "実行引数"
+          }
+        }
+      }
+    },
+    "SF Symbol Name": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "SF Symbol Name"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "SF Symbol 名称"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "SF Symbol 名"
+          }
+        }
+      }
+    },
+    "Save": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Save"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "保存"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "保存"
+          }
+        }
+      }
+    },
+    "Separate multiple arguments with semicolons (;)": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Separate multiple arguments with semicolons (;)"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "多个参数用分号（;）分隔"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "複数の引数はセミコロン（;）で区切ってください"
+          }
+        }
+      }
+    },
+    "Settings": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Settings"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "设置"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "設定"
+          }
+        }
+      }
+    },
+    "Settings Management": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Settings Management"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "设置管理"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "設定管理"
+          }
+        }
+      }
+    },
+    "Settings…": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Settings…"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "设置…"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "設定…"
+          }
+        }
+      }
+    },
+    "Show icon in menu bar": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Show icon in menu bar"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "在菜单栏显示图标"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "メニューバーにアイコンを表示"
+          }
+        }
+      }
+    },
+    "Simplified Chinese": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Simplified Chinese"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "简体中文"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "简体中文"
+          }
+        }
+      }
+    },
+    "Template": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Template"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "模板"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "テンプレート"
+          }
+        }
+      }
+    },
+    "The application bundle is invalid or damaged.": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "The application bundle is invalid or damaged."
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "应用程序包无效或损坏。"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "アプリケーションバンドルが無効または破損しています。"
+          }
+        }
+      }
+    },
+    "The application has been updated successfully. Restart the app to finish the update.": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "The application has been updated successfully. Restart the app to finish the update."
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "应用程序已成功更新。需要重启应用来完成更新过程。"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "アプリケーションは正常に更新されました。更新を完了するにはアプリを再起動してください。"
+          }
+        }
+      }
+    },
+    "The current folder cannot be deleted. Please select files or subfolders instead.": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "The current folder cannot be deleted. Please select files or subfolders instead."
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "无法删除当前文件夹，请选择文件或子文件夹进行删除。"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "現在のフォルダは削除できません。代わりにファイルまたはサブフォルダを選択してください。"
+          }
+        }
+      }
+    },
+    "The current folder cannot be shared. Please select files or subfolders instead.": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "The current folder cannot be shared. Please select files or subfolders instead."
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "无法共享当前文件夹，请选择文件或子文件夹进行共享。"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "現在のフォルダは共有できません。代わりにファイルまたはサブフォルダを選択してください。"
+          }
+        }
+      }
+    },
+    "The current version is already up to date.": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "The current version is already up to date."
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "当前版本已是最新，无需更新。"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "現在のバージョンはすでに最新です。"
+          }
+        }
+      }
+    },
+    "The selected folder is a subfolder of an already selected folder. Please choose a different folder.": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "The selected folder is a subfolder of an already selected folder. Please choose a different folder."
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "所选文件夹是已选文件夹的子目录，请选择其他文件夹。"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "選択したフォルダは既に選択済みのフォルダのサブフォルダです。別のフォルダを選択してください。"
+          }
+        }
+      }
+    },
+    "The user cancelled authorization.": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "The user cancelled authorization."
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "用户取消了授权。"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "ユーザーが認証をキャンセルしました。"
+          }
+        }
+      }
+    },
+    "This will delete all custom configurations and restore the defaults. This action cannot be undone.": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "This will delete all custom configurations and restore the defaults. This action cannot be undone."
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "此操作将删除所有自定义配置，恢复到默认状态。此操作不可逆。"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "この操作によりすべてのカスタム設定が削除され、既定値に戻ります。元に戻すことはできません。"
+          }
+        }
+      }
+    },
+    "Unauthorized Folder": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Unauthorized Folder"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "未授权文件夹"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "未承認のフォルダ"
+          }
+        }
+      }
+    },
+    "Unknown": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Unknown"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "未知"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "不明"
+          }
+        }
+      }
+    },
+    "Untitled": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Untitled"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "未命名"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "名称未設定"
+          }
+        }
+      }
+    },
+    "Up to Date": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Up to Date"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "已是最新版本"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "最新です"
+          }
+        }
+      }
+    },
+    "Update Installed": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Update Installed"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "更新安装完成"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "アップデートがインストールされました"
+          }
+        }
+      }
+    },
+    "Version %@": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Version %@"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "版本 %@"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "バージョン %@"
+          }
+        }
+      }
+    },
+    "Version %@ (%@)": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Version %@ (%@)"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "版本 %@ (%@)"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "バージョン %@ (%@)"
+          }
+        }
+      }
+    },
+    "Version %@ is ignored": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Version %@ is ignored"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "已忽略版本 %@"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "バージョン %@ は無視されています"
+          }
+        }
+      }
+    },
+    "Warning": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Warning"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "警告"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "警告"
+          }
+        }
+      }
     }
   },
-  "version" : "1.0"
+  "version": "1.0"
 }

--- a/RClick.xcodeproj/project.pbxproj
+++ b/RClick.xcodeproj/project.pbxproj
@@ -368,6 +368,8 @@
 			knownRegions = (
 				en,
 				Base,
+				"zh-Hans",
+				ja,
 			);
 			mainGroup = 5C8A28D12F83D65900FE687C;
 			minimizedProjectReferenceProxies = 1;

--- a/RClick/AppState.swift
+++ b/RClick/AppState.swift
@@ -25,6 +25,7 @@ class AppState: ObservableObject {
     @Published var cdirs: [CommonDir] = []
     @Published var inExt: Bool
     @Published var hasFullDiskAccess: Bool = false
+    @Published var locale: Locale
 
     // 折叠开关状态 - 每个分类独立控制
     @AppStorage("foldAppsMenu") var foldAppsMenu: Bool = false
@@ -36,16 +37,38 @@ class AppState: ObservableObject {
 
     // 菜单栏显示
     @AppStorage(Key.showMenuBarExtra) var showMenuBar: Bool = true
+    @AppStorage(Key.selectedLanguage, store: .group) private var selectedLanguageRawValue = AppLanguage.automatic.rawValue
 
     // SwiftData ModelContext（lazy 复用单个实例）
     private lazy var modelContext = ModelContext(SharedDataManager.sharedModelContainer)
 
     init(inExt: Bool = false) {
         self.inExt = inExt
+        self.locale = AppLocalization.currentLocale
         Task { @MainActor in
             logger.debug("start load")
             try? load()
             checkFullDiskAccess()
+        }
+
+        NotificationCenter.default.addObserver(
+            forName: NSLocale.currentLocaleDidChangeNotification,
+            object: nil,
+            queue: .main
+        ) { [weak self] _ in
+            Task { @MainActor in
+                guard let self = self, self.selectedLanguage == .automatic else { return }
+                self.locale = AppLocalization.currentLocale
+            }
+        }
+    }
+
+    var selectedLanguage: AppLanguage {
+        get { AppLanguage(rawValue: selectedLanguageRawValue) ?? .automatic }
+        set {
+            selectedLanguageRawValue = newValue.rawValue
+            locale = Locale(identifier: newValue.localeIdentifier)
+            NotificationCenter.default.post(name: .menuConfigShouldUpdate, object: nil)
         }
     }
 

--- a/RClick/Localizable.xcstrings
+++ b/RClick/Localizable.xcstrings
@@ -1,1181 +1,3798 @@
 {
-  "sourceLanguage" : "en",
-  "strings" : {
-    "" : {
-      "extractionState" : "stale",
-      "localizations" : {
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : ""
+  "sourceLanguage": "en",
+  "strings": {
+    "": {
+      "extractionState": "stale",
+      "localizations": {
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": ""
           }
         }
       }
     },
-    "%@" : {
-
-    },
-    "%@（%@）" : {
-      "extractionState" : "stale",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "%1$@（%2$@）"
+    "%@": {},
+    "%@（%@）": {
+      "extractionState": "stale",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "new",
+            "value": "%1$@（%2$@）"
           }
         },
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "%1$@（%2$@）"
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%1$@（%2$@）"
           }
         }
       }
     },
-    "1. 点击右侧「设置…」按钮打开系统设置" : {
-
-    },
-    "2. 点击左下角锁图标并认证" : {
-
-    },
-    "3. 点击「+」→ 前往「应用程序」→ 选择「RClick」" : {
-
-    },
-    "4. 确保 RClick 旁边的开关已打开" : {
-
-    },
-    "About" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "About"
+    "1. 点击右侧「设置…」按钮打开系统设置": {},
+    "2. 点击左下角锁图标并认证": {},
+    "3. 点击「+」→ 前往「应用程序」→ 选择「RClick」": {},
+    "4. 确保 RClick 旁边的开关已打开": {},
+    "About": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "About"
           }
         },
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "关于"
-          }
-        }
-      }
-    },
-    "Actions" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Actions"
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "关于"
           }
         },
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "操作"
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "情報"
           }
         }
       }
     },
-    "Add" : {
-      "extractionState" : "stale",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Add"
+    "Actions": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Actions"
           }
         },
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "添加"
-          }
-        }
-      }
-    },
-    "Add New File Type" : {
-      "extractionState" : "stale",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Add New File Type"
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "操作"
           }
         },
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "添加新建文件类型"
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "操作"
           }
         }
       }
     },
-    "AirDrop" : {
-
-    },
-    "Apps" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Apps"
+    "Add": {
+      "extractionState": "stale",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Add"
           }
         },
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "菜单App"
-          }
-        }
-      }
-    },
-    "Arguments" : {
-      "extractionState" : "stale",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Arguments"
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "添加"
           }
         },
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "参数"
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "追加"
           }
         }
       }
     },
-    "Authorization folder" : {
-      "extractionState" : "stale",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Authorization folder"
+    "Add New File Type": {
+      "extractionState": "stale",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Add New File Type"
           }
         },
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "授权的文件夹"
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "添加新建文件类型"
           }
         }
       }
     },
-    "Cancel" : {
-      "extractionState" : "stale",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Cancel"
+    "AirDrop": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "AirDrop"
           }
         },
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "取消"
-          }
-        }
-      }
-    },
-    "Common Dir" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Common Dir"
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "AirDrop"
           }
         },
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "常用文件夹"
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "AirDrop"
           }
         }
       }
     },
-    "Common Dirs" : {
-      "extractionState" : "stale",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Common Dirs"
+    "Apps": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Apps"
           }
         },
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "常用文件夹"
-          }
-        }
-      }
-    },
-    "Common Folders" : {
-      "extractionState" : "stale",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Common Folders"
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "应用"
           }
         },
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "常用文件夹"
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "アプリ"
           }
         }
       }
     },
-    "Copy Path" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Copy Path"
+    "Arguments": {
+      "extractionState": "stale",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Arguments"
           }
         },
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "复制路径"
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "参数"
           }
         }
       }
     },
-    "Default Open App" : {
-      "extractionState" : "stale",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Default Open App"
+    "Authorization folder": {
+      "extractionState": "stale",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Authorization folder"
           }
         },
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "默认打开 App"
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "授权的文件夹"
           }
         }
       }
     },
-    "Delete Direct" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Delete Direct"
+    "Cancel": {
+      "extractionState": "stale",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Cancel"
           }
         },
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "直接删除"
-          }
-        }
-      }
-    },
-    "Display Name" : {
-      "extractionState" : "stale",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Display Name"
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "取消"
           }
         },
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "显示名称"
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "キャンセル"
           }
         }
       }
     },
-    "DOCX" : {
-      "extractionState" : "stale",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "DOCX"
+    "Common Dir": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Common Folders"
           }
         },
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Word 文档"
-          }
-        }
-      }
-    },
-    "Don't Ask Again" : {
-
-    },
-    "Edit App Properties" : {
-      "extractionState" : "stale",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Edit App Properties"
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "常用文件夹"
           }
         },
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "编辑App 属性"
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "よく使うフォルダ"
           }
         }
       }
     },
-    "Enable extension" : {
-      "extractionState" : "stale",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Enable extension"
+    "Common Dirs": {
+      "extractionState": "stale",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Common Folders"
           }
         },
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "启用扩展"
-          }
-        }
-      }
-    },
-    "Enable Full Disk Access" : {
-
-    },
-    "Environment Variables" : {
-      "extractionState" : "stale",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Environment Variables"
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "常用文件夹"
           }
         },
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "环境变量"
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "よく使うフォルダ"
           }
         }
       }
     },
-    "Favorite Folders" : {
-      "extractionState" : "stale",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Favorite Folders"
+    "Common Folders": {
+      "extractionState": "stale",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Common Folders"
           }
         },
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "常用文件夹"
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "常用文件夹"
           }
         }
       }
     },
-    "Finder 扩展" : {
-
-    },
-    "General" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "General"
+    "Copy Path": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Copy Path"
           }
         },
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "通用"
-          }
-        }
-      }
-    },
-    "github.com/wflixu/RClick" : {
-
-    },
-    "Hide" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Hide"
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "复制路径"
           }
         },
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "隐藏"
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "パスをコピー"
           }
         }
       }
     },
-    "Invalid Folder Selection" : {
-      "extractionState" : "stale",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Invalid Folder Selection"
+    "Default Open App": {
+      "extractionState": "stale",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Default Open App"
           }
         },
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "无效的文件夹选择"
-          }
-        }
-      }
-    },
-    "JSON" : {
-      "extractionState" : "stale",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "JSON"
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "默认打开应用"
           }
         },
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "JSON 文件"
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "既定で開くアプリ"
           }
         }
       }
     },
-    "Later" : {
-
-    },
-    "Launch at login" : {
-      "extractionState" : "stale",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Launch at login"
+    "Delete Direct": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Delete Direct"
           }
         },
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "登录时启动"
-          }
-        }
-      }
-    },
-    "Markdown" : {
-      "extractionState" : "stale",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Markdown"
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "直接删除"
           }
         },
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Markdown 文档"
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "直接削除"
           }
         }
       }
     },
-    "New File" : {
-      "extractionState" : "stale",
-      "localizations" : {
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "新建文件"
-          }
-        }
-      }
-    },
-    "Not Authorized Folder" : {
-      "extractionState" : "stale",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Not Authorized Folder"
+    "Display Name": {
+      "extractionState": "stale",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Display Name"
           }
         },
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "无授权文件夹"
-          }
-        }
-      }
-    },
-    "OK" : {
-      "extractionState" : "stale",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "OK"
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "显示名称"
           }
         },
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "确认"
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "表示名"
           }
         }
       }
     },
-    "Open Settings" : {
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Open Settings"
+    "DOCX": {
+      "extractionState": "stale",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "DOCX"
           }
         },
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "打开设置"
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Word 文档"
           }
         }
       }
     },
-    "Open With" : {
-      "extractionState" : "stale",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Open With"
+    "Don't Ask Again": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Don't Ask Again"
           }
         },
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "用...打开"
-          }
-        }
-      }
-    },
-    "Open With %@" : {
-      "extractionState" : "stale",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Open With %@"
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "不再询问"
           }
         },
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "用 %@ 打开"
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "今後表示しない"
           }
         }
       }
     },
-    "PPTX" : {
-      "extractionState" : "stale",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "PPTX"
+    "Edit App Properties": {
+      "extractionState": "stale",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Edit App Properties"
           }
         },
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "PowerPoint 演示文稿"
-          }
-        }
-      }
-    },
-    "Quit" : {
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Quit"
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "编辑应用属性"
           }
         },
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "停止"
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "アプリ設定を編集"
           }
         }
       }
     },
-    "RClick" : {
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "RClick"
+    "Enable extension": {
+      "extractionState": "stale",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Enable extension"
           }
         },
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "RClick"
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "启用扩展"
           }
         }
       }
     },
-    "RClick (loading...)" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "RClick (loading...)"
+    "Enable Full Disk Access": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Enable Full Disk Access"
           }
         },
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "RClick (加载中...)"
-          }
-        }
-      }
-    },
-    "RClick is a right-click menu extension that allows you to add applications for opening folders and includes some common actions!" : {
-      "extractionState" : "stale",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "RClick is a right-click menu extension that allows you to add applications for opening folders and includes some common actions!"
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "启用完全磁盘访问权限"
           }
         },
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "RClick 是一个右键菜单扩展，可以添加打开文件夹的应用，可以添加一些常用的操作！"
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "フルディスクアクセスを有効にする"
           }
         }
       }
     },
-    "RClick is a right-click menu extension that allows you to add applications for opening folders and includes some common actions." : {
-
-    },
-    "RClick needs Full Disk Access to create files, delete files, and manage hidden files in protected folders (like Desktop, Documents, and Downloads).\n\nWithout this permission, some operations may fail on protected directories.\n\nTo enable:\n1. Click \"Open Settings\" below\n2. Click the lock icon and authenticate\n3. Click \"+\" and add RClick from your Applications folder\n4. Toggle the switch next to RClick to ON" : {
-
-    },
-    "RClick 需要完全磁盘访问权限才能正常操作受保护目录中的文件" : {
-
-    },
-    "Reset" : {
-      "extractionState" : "stale",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Reset"
+    "Environment Variables": {
+      "extractionState": "stale",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Environment Variables"
           }
         },
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "重置"
-          }
-        }
-      }
-    },
-    "Save" : {
-      "extractionState" : "stale",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Save"
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "环境变量"
           }
         },
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "保存"
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "環境変数"
           }
         }
       }
     },
-    "Select App" : {
-      "extractionState" : "stale",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Select App"
+    "Favorite Folders": {
+      "extractionState": "stale",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Favorite Folders"
           }
         },
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "选择App"
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "常用文件夹"
           }
         }
       }
     },
-    "Settings" : {
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Settings"
+    "Finder 扩展": {},
+    "General": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "General"
           }
         },
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "设置"
-          }
-        }
-      }
-    },
-    "SF Symbol 名称" : {
-
-    },
-    "Show in dock" : {
-      "extractionState" : "stale",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Show in dock"
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "通用"
           }
         },
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "在 Dock 栏显示"
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "一般"
           }
         }
       }
     },
-    "Show in menu bar" : {
-      "extractionState" : "stale",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Show in menu bar"
+    "github.com/wflixu/RClick": {},
+    "Hide": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Hide"
           }
         },
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "在菜单栏显示"
-          }
-        }
-      }
-    },
-    "The operation of the menu can only be executed in authorized folders" : {
-      "extractionState" : "stale",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "The operation of the menu can only be executed in authorized folders"
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "隐藏"
           }
         },
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "菜单中的操作在授权文件夹中才能执行"
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "隠す"
           }
         }
       }
     },
-    "The RClick extension needs to be enabled for it to work properly" : {
-      "extractionState" : "stale",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "The RClick extension needs to be enabled for it to work properly"
+    "Invalid Folder Selection": {
+      "extractionState": "stale",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Invalid Folder Selection"
           }
         },
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "RClick 需要启用 扩展才能正常工作"
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "无效的文件夹选择"
           }
         }
       }
     },
-    "The selected folder is a subdirectory of the previously chosen folder. Please select a different folder." : {
-      "extractionState" : "stale",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "The selected folder is a subdirectory of the previously chosen folder. Please select a different folder."
+    "JSON": {
+      "extractionState": "stale",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "JSON"
           }
         },
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "选择的文件夹已经包含在已授权的文件夹中"
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "JSON 文件"
           }
         }
       }
     },
-    "TXT" : {
-      "extractionState" : "stale",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "TXT"
+    "Later": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Later"
           }
         },
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "TXT 文本"
-          }
-        }
-      }
-    },
-    "Unhide" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Unhide"
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "稍后"
           }
         },
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "显示"
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "あとで"
           }
         }
       }
     },
-    "Untitled" : {
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Untitled"
+    "Launch at login": {
+      "extractionState": "stale",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Launch at login"
           }
         },
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "未命名"
-          }
-        }
-      }
-    },
-    "Version %@ (%@)" : {
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Version %1$@ (%2$@)"
-          }
-        }
-      }
-    },
-    "Want to add a feature? Give feedback here." : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Want to add a feature? Give feedback here."
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "登录时启动"
           }
         },
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "需要添加新功能，在这里反馈"
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "ログイン時に起動"
           }
         }
       }
     },
-    "XLSX" : {
-      "extractionState" : "stale",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "XLSX"
+    "Markdown": {
+      "extractionState": "stale",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Markdown"
           }
         },
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Excel 表格"
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Markdown 文档"
           }
         }
       }
     },
-    "You must grant access to the folder to use this feature." : {
-      "extractionState" : "stale",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "You must grant access to the folder to use this feature."
+    "New File": {
+      "extractionState": "stale",
+      "localizations": {
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "新建文件"
           }
         },
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "你必须选择至少一个文件夹才能使用"
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "New File"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "新規ファイル"
           }
         }
       }
     },
-    "下载并安装" : {
-
-    },
-    "主要控制" : {
-
-    },
-    "例如：txt、md、json" : {
-
-    },
-    "保存" : {
-
-    },
-    "删除应用" : {
-
-    },
-    "参数（分号分隔）" : {
-
-    },
-    "发现新版本" : {
-
-    },
-    "取消" : {
-
-    },
-    "名称" : {
-
-    },
-    "启用" : {
-
-    },
-    "启用 RClick" : {
-
-    },
-    "启用常用文件夹" : {
-
-    },
-    "图标" : {
-
-    },
-    "在文件提供程序中启用 RClick 以在右键菜单中显示功能" : {
-
-    },
-    "在菜单栏显示图标" : {
-
-    },
-    "备份" : {
-
-    },
-    "多个参数用分号（;）分隔" : {
-
-    },
-    "完全磁盘访问权限" : {
-
-    },
-    "完全磁盘访问权限：用于在受保护目录中创建和删除文件" : {
-
-    },
-    "导入…" : {
-
-    },
-    "导出…" : {
-
-    },
-    "导出日志…" : {
-
-    },
-    "已是最新版本" : {
-
-    },
-    "已添加的文件夹" : {
-
-    },
-    "当前版本已是最新，无需更新。" : {
-
-    },
-    "必须授予文件夹访问权限才能使用此功能。" : {
-
-    },
-    "忽略此版本" : {
-
-    },
-    "恢复到默认设置" : {
-
-    },
-    "恢复默认" : {
-
-    },
-    "所选文件夹是已选文件夹的子目录，请选择其他文件夹。" : {
-
-    },
-    "手动下载" : {
-
-    },
-    "扩展名" : {
-
-    },
-    "扩展名: %@" : {
-
-    },
-    "折叠动作菜单" : {
-
-    },
-    "折叠应用菜单" : {
-
-    },
-    "折叠新建文件菜单" : {
-
-    },
-    "折叠菜单" : {
-
-    },
-    "文件扩展名" : {
-
-    },
-    "文件提供程序：在列表中选择「RClick」以启用 Finder 右键菜单" : {
-
-    },
-    "无效文件夹" : {
-
-    },
-    "日志" : {
-
-    },
-    "显示名称" : {
-
-    },
-    "更换应用" : {
-
-    },
-    "更换模板" : {
-
-    },
-    "未授权文件夹" : {
-
-    },
-    "权限" : {
-
-    },
-    "格式：KEY=VALUE，每行一个" : {
-
-    },
-    "检查更新" : {
-
-    },
-    "检查更新失败" : {
-
-    },
-    "模板" : {
-
-    },
-    "正在检查更新..." : {
-
-    },
-    "添加" : {
-
-    },
-    "添加应用" : {
-
-    },
-    "添加文件夹" : {
-
-    },
-    "添加文件类型" : {
-
-    },
-    "版本 %@" : {
-
-    },
-    "环境变量" : {
-
-    },
-    "登录时启动" : {
-
-    },
-    "确定" : {
-
-    },
-    "编辑应用" : {
-
-    },
-    "编辑应用属性" : {
-
-    },
-    "编辑文件类型" : {
-
-    },
-    "设置…" : {
-
-    },
-    "设置管理" : {
-
-    },
-    "辅助功能" : {
-
-    },
-    "输入 SF Symbol 名称，例如 doc.text、curlybraces" : {
-
-    },
-    "运行参数" : {
-
-    },
-    "选择模板文件" : {
-
-    },
-    "选择默认打开应用" : {
-
-    },
-    "重置所有设置…" : {
-
-    },
-    "重置所有设置将恢复默认配置，此操作不可逆" : {
-
-    },
-    "预览:" : {
-
-    },
-    "默认打开应用" : {
-
+    "Not Authorized Folder": {
+      "extractionState": "stale",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Not Authorized Folder"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "无授权文件夹"
+          }
+        }
+      }
+    },
+    "OK": {
+      "extractionState": "stale",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "OK"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "确定"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "OK"
+          }
+        }
+      }
+    },
+    "Open Settings": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Open Settings"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "打开设置"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "設定を開く"
+          }
+        }
+      },
+      "extractionState": "manual"
+    },
+    "Open With": {
+      "extractionState": "stale",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Open With"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "用...打开"
+          }
+        }
+      }
+    },
+    "Open With %@": {
+      "extractionState": "stale",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Open With %@"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "用 %@ 打开"
+          }
+        }
+      }
+    },
+    "PPTX": {
+      "extractionState": "stale",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "PPTX"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "PowerPoint 演示文稿"
+          }
+        }
+      }
+    },
+    "Quit": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Quit"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "退出"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "終了"
+          }
+        }
+      },
+      "extractionState": "manual"
+    },
+    "RClick": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "RClick"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "RClick"
+          }
+        }
+      }
+    },
+    "RClick (loading...)": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "RClick (loading...)"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "RClick（加载中...）"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "RClick（読み込み中...）"
+          }
+        }
+      }
+    },
+    "RClick is a right-click menu extension that allows you to add applications for opening folders and includes some common actions!": {
+      "extractionState": "stale",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "RClick is a right-click menu extension that allows you to add applications for opening folders and includes some common actions!"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "RClick 是一个右键菜单扩展，可以添加打开文件夹的应用，可以添加一些常用的操作！"
+          }
+        }
+      }
+    },
+    "RClick is a right-click menu extension that allows you to add applications for opening folders and includes some common actions.": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "RClick is a right-click menu extension that allows you to add applications for opening folders and includes some common actions."
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "RClick 是一个右键菜单扩展，可以添加打开文件夹的应用，并提供一些常用操作。"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "RClick はフォルダを開くアプリを追加できる右クリックメニュー拡張で、いくつかの便利な操作も含まれています。"
+          }
+        }
+      }
+    },
+    "RClick needs Full Disk Access to create files, delete files, and manage hidden files in protected folders (like Desktop, Documents, and Downloads).\n\nWithout this permission, some operations may fail on protected directories.\n\nTo enable:\n1. Click \"Open Settings\" below\n2. Click the lock icon and authenticate\n3. Click \"+\" and add RClick from your Applications folder\n4. Toggle the switch next to RClick to ON": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "RClick needs Full Disk Access to create files, delete files, and manage hidden files in protected folders (like Desktop, Documents, and Downloads).\n\nWithout this permission, some operations may fail on protected directories.\n\nTo enable:\n1. Click \"Open Settings\" below\n2. Click the lock icon and authenticate\n3. Click \"+\" and add RClick from your Applications folder\n4. Toggle the switch next to RClick to ON"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "RClick 需要完全磁盘访问权限，才能在受保护文件夹中创建文件、删除文件和管理隐藏文件，例如桌面、文稿和下载。\n\n没有此权限时，某些操作可能会在受保护目录中失败。\n\n启用方法：\n1. 点击下方“打开设置”\n2. 点击锁图标并认证\n3. 点击“+”，从“应用程序”文件夹添加 RClick\n4. 打开 RClick 旁边的开关"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "RClick がデスクトップ、書類、ダウンロードなどの保護されたフォルダでファイルの作成、削除、隠しファイルの管理を行うには、フルディスクアクセスが必要です。\n\nこの権限がない場合、保護されたディレクトリで一部の操作が失敗することがあります。\n\n有効にするには:\n1. 下の「設定を開く」をクリックします\n2. 鍵アイコンをクリックして認証します\n3. 「+」をクリックし、アプリケーションフォルダから RClick を追加します\n4. RClick の横にあるスイッチをオンにします"
+          }
+        }
+      }
+    },
+    "RClick 需要完全磁盘访问权限才能正常操作受保护目录中的文件": {},
+    "Reset": {
+      "extractionState": "stale",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Reset"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "重置"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "リセット"
+          }
+        }
+      }
+    },
+    "Save": {
+      "extractionState": "stale",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Save"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "保存"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "保存"
+          }
+        }
+      }
+    },
+    "Select App": {
+      "extractionState": "stale",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Select App"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "选择App"
+          }
+        }
+      }
+    },
+    "Settings": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Settings"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "设置"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "設定"
+          }
+        }
+      },
+      "extractionState": "manual"
+    },
+    "SF Symbol 名称": {},
+    "Show in dock": {
+      "extractionState": "stale",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Show in dock"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "在 Dock 栏显示"
+          }
+        }
+      }
+    },
+    "Show in menu bar": {
+      "extractionState": "stale",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Show in menu bar"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "在菜单栏显示"
+          }
+        }
+      }
+    },
+    "The operation of the menu can only be executed in authorized folders": {
+      "extractionState": "stale",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "The operation of the menu can only be executed in authorized folders"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "菜单中的操作在授权文件夹中才能执行"
+          }
+        }
+      }
+    },
+    "The RClick extension needs to be enabled for it to work properly": {
+      "extractionState": "stale",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "The RClick extension needs to be enabled for it to work properly"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "RClick 需要启用 扩展才能正常工作"
+          }
+        }
+      }
+    },
+    "The selected folder is a subdirectory of the previously chosen folder. Please select a different folder.": {
+      "extractionState": "stale",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "The selected folder is a subdirectory of the previously chosen folder. Please select a different folder."
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "选择的文件夹已经包含在已授权的文件夹中"
+          }
+        }
+      }
+    },
+    "TXT": {
+      "extractionState": "stale",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "TXT"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "TXT 文本"
+          }
+        }
+      }
+    },
+    "Unhide": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Unhide"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "显示"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "再表示"
+          }
+        }
+      }
+    },
+    "Untitled": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Untitled"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "未命名"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "名称未設定"
+          }
+        }
+      },
+      "extractionState": "manual"
+    },
+    "Version %@ (%@)": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Version %@ (%@)"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "版本 %@ (%@)"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "バージョン %@ (%@)"
+          }
+        }
+      },
+      "extractionState": "manual"
+    },
+    "Want to add a feature? Give feedback here.": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Want to add a feature? Give feedback here."
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "需要添加新功能，在这里反馈"
+          }
+        }
+      }
+    },
+    "XLSX": {
+      "extractionState": "stale",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "XLSX"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Excel 表格"
+          }
+        }
+      }
+    },
+    "You must grant access to the folder to use this feature.": {
+      "extractionState": "stale",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "You must grant access to the folder to use this feature."
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "你必须选择至少一个文件夹才能使用"
+          }
+        }
+      }
+    },
+    "下载并安装": {},
+    "主要控制": {},
+    "例如：txt、md、json": {},
+    "保存": {},
+    "删除应用": {},
+    "参数（分号分隔）": {},
+    "发现新版本": {},
+    "取消": {},
+    "名称": {},
+    "启用": {},
+    "启用 RClick": {},
+    "启用常用文件夹": {},
+    "图标": {},
+    "在文件提供程序中启用 RClick 以在右键菜单中显示功能": {},
+    "在菜单栏显示图标": {},
+    "备份": {},
+    "多个参数用分号（;）分隔": {},
+    "完全磁盘访问权限": {},
+    "完全磁盘访问权限：用于在受保护目录中创建和删除文件": {},
+    "导入…": {},
+    "导出…": {},
+    "导出日志…": {},
+    "已是最新版本": {},
+    "已添加的文件夹": {},
+    "当前版本已是最新，无需更新。": {},
+    "必须授予文件夹访问权限才能使用此功能。": {},
+    "忽略此版本": {},
+    "恢复到默认设置": {},
+    "恢复默认": {},
+    "所选文件夹是已选文件夹的子目录，请选择其他文件夹。": {},
+    "手动下载": {},
+    "扩展名": {},
+    "扩展名: %@": {},
+    "折叠动作菜单": {},
+    "折叠应用菜单": {},
+    "折叠新建文件菜单": {},
+    "折叠菜单": {},
+    "文件扩展名": {},
+    "文件提供程序：在列表中选择「RClick」以启用 Finder 右键菜单": {},
+    "无效文件夹": {},
+    "日志": {},
+    "显示名称": {},
+    "更换应用": {},
+    "更换模板": {},
+    "未授权文件夹": {},
+    "权限": {},
+    "格式：KEY=VALUE，每行一个": {},
+    "检查更新": {},
+    "检查更新失败": {},
+    "模板": {},
+    "正在检查更新...": {},
+    "添加": {},
+    "添加应用": {},
+    "添加文件夹": {},
+    "添加文件类型": {},
+    "版本 %@": {},
+    "环境变量": {},
+    "登录时启动": {},
+    "确定": {},
+    "编辑应用": {},
+    "编辑应用属性": {},
+    "编辑文件类型": {},
+    "设置…": {},
+    "设置管理": {},
+    "辅助功能": {},
+    "输入 SF Symbol 名称，例如 doc.text、curlybraces": {},
+    "运行参数": {},
+    "选择模板文件": {},
+    "选择默认打开应用": {},
+    "重置所有设置…": {},
+    "重置所有设置将恢复默认配置，此操作不可逆": {},
+    "预览:": {},
+    "默认打开应用": {},
+    "1. Click \"Settings…\" on the right to open System Settings": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "1. Click \"Settings…\" on the right to open System Settings"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "1. 点击右侧“设置…”按钮打开系统设置"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "1. 右側の「設定…」をクリックしてシステム設定を開きます"
+          }
+        }
+      }
+    },
+    "2. Click the lock icon and authenticate": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "2. Click the lock icon and authenticate"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "2. 点击左下角锁图标并认证"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "2. 左下の鍵アイコンをクリックして認証します"
+          }
+        }
+      }
+    },
+    "3. Click \"+\" -> open \"Applications\" -> select \"RClick\"": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "3. Click \"+\" -> open \"Applications\" -> select \"RClick\""
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "3. 点击“+”并前往“应用程序”，选择“RClick”"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "3. 「+」を押して「アプリケーション」から「RClick」を選択します"
+          }
+        }
+      }
+    },
+    "4. Make sure the switch next to RClick is turned on": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "4. Make sure the switch next to RClick is turned on"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "4. 确保 RClick 旁边的开关已打开"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "4. RClick の横にあるスイッチがオンになっていることを確認します"
+          }
+        }
+      }
+    },
+    "Accessibility": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Accessibility"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "辅助功能"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "アクセシビリティ"
+          }
+        }
+      }
+    },
+    "Add App": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Add App"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "添加应用"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "アプリを追加"
+          }
+        }
+      }
+    },
+    "Add File Type": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Add File Type"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "添加文件类型"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "ファイル種類を追加"
+          }
+        }
+      }
+    },
+    "Add Folder": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Add Folder"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "添加文件夹"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "フォルダを追加"
+          }
+        }
+      }
+    },
+    "Added Folders": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Added Folders"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "已添加的文件夹"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "追加済みフォルダ"
+          }
+        }
+      }
+    },
+    "Applications": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Applications"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "应用程序"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "アプリケーション"
+          }
+        }
+      }
+    },
+    "Arguments (semicolon separated)": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Arguments (semicolon separated)"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "参数（分号分隔）"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "引数（セミコロン区切り）"
+          }
+        }
+      }
+    },
+    "Arguments: %@": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Arguments: %@"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "参数：%@"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "引数: %@"
+          }
+        }
+      }
+    },
+    "Authorized": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Authorized"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "已授权"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "許可済み"
+          }
+        }
+      }
+    },
+    "Automatic": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Automatic"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "自动"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "自動"
+          }
+        }
+      }
+    },
+    "Backup": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Backup"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "备份"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "バックアップ"
+          }
+        }
+      }
+    },
+    "Change App": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Change App"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "更换应用"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "アプリを変更"
+          }
+        }
+      }
+    },
+    "Change Template": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Change Template"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "更换模板"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "テンプレートを変更"
+          }
+        }
+      }
+    },
+    "Check for Updates": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Check for Updates"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "检查更新"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "アップデートを確認"
+          }
+        }
+      }
+    },
+    "Checking for updates...": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Checking for updates..."
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "正在检查更新..."
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "アップデートを確認中..."
+          }
+        }
+      }
+    },
+    "Choose Default App": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Choose Default App"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "选择默认打开应用"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "既定アプリを選択"
+          }
+        }
+      }
+    },
+    "Choose Template File": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Choose Template File"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "选择模板文件"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "テンプレートファイルを選択"
+          }
+        }
+      }
+    },
+    "Collapse actions menu": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Collapse actions menu"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "折叠动作菜单"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "操作メニューを折りたたむ"
+          }
+        }
+      }
+    },
+    "Collapse apps menu": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Collapse apps menu"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "折叠应用菜单"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "アプリメニューを折りたたむ"
+          }
+        }
+      }
+    },
+    "Collapse menu": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Collapse menu"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "折叠菜单"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "メニューを折りたたむ"
+          }
+        }
+      }
+    },
+    "Collapse new file menu": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Collapse new file menu"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "折叠新建文件菜单"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "新規ファイルメニューを折りたたむ"
+          }
+        }
+      }
+    },
+    "Delete App": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Delete App"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "删除应用"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "アプリを削除"
+          }
+        }
+      }
+    },
+    "Desktop": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Desktop"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "桌面"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "デスクトップ"
+          }
+        }
+      }
+    },
+    "Documents": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Documents"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "文档"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "書類"
+          }
+        }
+      }
+    },
+    "Download Manually": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Download Manually"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "手动下载"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "手動でダウンロード"
+          }
+        }
+      }
+    },
+    "Download and Install": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Download and Install"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "下载并安装"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "ダウンロードしてインストール"
+          }
+        }
+      }
+    },
+    "Downloads": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Downloads"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "下载"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "ダウンロード"
+          }
+        }
+      }
+    },
+    "Edit App": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Edit App"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "编辑应用"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "アプリを編集"
+          }
+        }
+      }
+    },
+    "Edit File Type": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Edit File Type"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "编辑文件类型"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "ファイル種類を編集"
+          }
+        }
+      }
+    },
+    "Enable RClick": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Enable RClick"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "启用 RClick"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "RClick を有効にする"
+          }
+        }
+      }
+    },
+    "Enable RClick in File Provider to show its actions in Finder context menus": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Enable RClick in File Provider to show its actions in Finder context menus"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "在文件提供程序中启用 RClick 以在 Finder 右键菜单中显示功能"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "ファイルプロバイダで RClick を有効にすると Finder の右クリックメニューに表示されます"
+          }
+        }
+      }
+    },
+    "Enable common folders": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Enable common folders"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "启用常用文件夹"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "よく使うフォルダを有効化"
+          }
+        }
+      }
+    },
+    "Enabled": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Enabled"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "启用"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "有効"
+          }
+        }
+      }
+    },
+    "English": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "English"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "English"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "English"
+          }
+        }
+      }
+    },
+    "Enter an SF Symbol name, for example doc.text or curlybraces": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Enter an SF Symbol name, for example doc.text or curlybraces"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "输入 SF Symbol 名称，例如 doc.text、curlybraces"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "SF Symbol 名を入力してください。例: doc.text、curlybraces"
+          }
+        }
+      }
+    },
+    "Environment variables: %lld": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Environment variables: %lld"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "环境变量：%lld 个"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "環境変数: %lld 個"
+          }
+        }
+      }
+    },
+    "Export Logs…": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Export Logs…"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "导出日志…"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "ログを書き出し…"
+          }
+        }
+      }
+    },
+    "Export…": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Export…"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "导出…"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "書き出し…"
+          }
+        }
+      }
+    },
+    "Extension: %@": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Extension: %@"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "扩展名：%@"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "拡張子: %@"
+          }
+        }
+      }
+    },
+    "Extraction failed: %@": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Extraction failed: %@"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "解压失败：%@"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "展開に失敗しました: %@"
+          }
+        }
+      }
+    },
+    "Failed to Check for Updates": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Failed to Check for Updates"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "检查更新失败"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "アップデートの確認に失敗しました"
+          }
+        }
+      }
+    },
+    "File Extension": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "File Extension"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "文件扩展名"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "ファイル拡張子"
+          }
+        }
+      }
+    },
+    "File Provider: Select \"RClick\" in the list to enable the Finder context menu": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "File Provider: Select \"RClick\" in the list to enable the Finder context menu"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "文件提供程序：在列表中选择“RClick”以启用 Finder 右键菜单"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "ファイルプロバイダ一覧で「RClick」を選択すると Finder の右クリックメニューを有効にできます"
+          }
+        }
+      }
+    },
+    "Finder Extension": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Finder Extension"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Finder 扩展"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Finder 拡張"
+          }
+        }
+      }
+    },
+    "Folder access permission is required to use this feature.": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Folder access permission is required to use this feature."
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "必须授予文件夹访问权限才能使用此功能。"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "この機能を使うにはフォルダへのアクセス許可が必要です。"
+          }
+        }
+      }
+    },
+    "Folders cannot be shared via AirDrop: %@": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Folders cannot be shared via AirDrop: %@"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "不能通过 AirDrop 分享文件夹：%@"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "フォルダは AirDrop で共有できません: %@"
+          }
+        }
+      }
+    },
+    "For example: txt, md, json": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "For example: txt, md, json"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "例如：txt、md、json"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "例: txt、md、json"
+          }
+        }
+      }
+    },
+    "Format: KEY=VALUE, one per line": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Format: KEY=VALUE, one per line"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "格式：KEY=VALUE，每行一个"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "形式: KEY=VALUE を1行ずつ入力"
+          }
+        }
+      }
+    },
+    "Full Disk Access": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Full Disk Access"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "完全磁盘访问权限"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "フルディスクアクセス"
+          }
+        }
+      }
+    },
+    "Full Disk Access: Required to create and delete files in protected directories": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Full Disk Access: Required to create and delete files in protected directories"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "完全磁盘访问权限：用于在受保护目录中创建和删除文件"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "フルディスクアクセスは保護されたディレクトリでのファイル作成と削除に必要です"
+          }
+        }
+      }
+    },
+    "Grant Permission": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Grant Permission"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "授予权限"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "権限を付与"
+          }
+        }
+      }
+    },
+    "Home": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Home"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "用户主目录"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "ホーム"
+          }
+        }
+      }
+    },
+    "Icon": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Icon"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "图标"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "アイコン"
+          }
+        }
+      }
+    },
+    "Ignore This Version": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Ignore This Version"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "忽略此版本"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "このバージョンを無視"
+          }
+        }
+      }
+    },
+    "Import…": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Import…"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "导入…"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "読み込み…"
+          }
+        }
+      }
+    },
+    "Installation failed: %@": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Installation failed: %@"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "安装失败：%@"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "インストールに失敗しました: %@"
+          }
+        }
+      }
+    },
+    "Invalid Folder": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Invalid Folder"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "无效文件夹"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "無効なフォルダ"
+          }
+        }
+      }
+    },
+    "Japanese": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Japanese"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "日本語"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "日本語"
+          }
+        }
+      }
+    },
+    "Language": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Language"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "语言"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "言語"
+          }
+        }
+      }
+    },
+    "Logs": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Logs"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "日志"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "ログ"
+          }
+        }
+      }
+    },
+    "Main Controls": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Main Controls"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "主要控制"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "メイン設定"
+          }
+        }
+      }
+    },
+    "Name": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Name"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "名称"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "名称"
+          }
+        }
+      }
+    },
+    "New Version Available": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "New Version Available"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "发现新版本"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "新しいバージョンがあります"
+          }
+        }
+      }
+    },
+    "No .app application was found in the ZIP file.": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "No .app application was found in the ZIP file."
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "在 ZIP 文件中未找到 .app 应用程序。"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "ZIP ファイル内に .app アプリケーションが見つかりません。"
+          }
+        }
+      }
+    },
+    "No .app.zip application package was found.": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "No .app.zip application package was found."
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "未找到 .app.zip 格式的应用程序包。"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": ".app.zip 形式のアプリケーションパッケージが見つかりません。"
+          }
+        }
+      }
+    },
+    "No update is available.": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "No update is available."
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "没有可用的更新。"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "利用可能なアップデートはありません。"
+          }
+        }
+      }
+    },
+    "Not Authorized": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Not Authorized"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "未授权"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "未許可"
+          }
+        }
+      }
+    },
+    "Notice": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Notice"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "提示"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "お知らせ"
+          }
+        }
+      }
+    },
+    "Permissions": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Permissions"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "权限"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "権限"
+          }
+        }
+      }
+    },
+    "Please select the correct Applications folder.": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Please select the correct Applications folder."
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "请选择正确的“应用程序”文件夹。"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "正しいアプリケーションフォルダを選択してください。"
+          }
+        }
+      }
+    },
+    "Preview:": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Preview:"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "预览："
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "プレビュー:"
+          }
+        }
+      }
+    },
+    "Protected system folders cannot be deleted: %@": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Protected system folders cannot be deleted: %@"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "无法删除系统保护文件夹：%@"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "保護されたシステムフォルダは削除できません: %@"
+          }
+        }
+      }
+    },
+    "Protected system folders cannot be shared: %@": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Protected system folders cannot be shared: %@"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "无法分享系统保护文件夹：%@"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "保護されたシステムフォルダは共有できません: %@"
+          }
+        }
+      }
+    },
+    "RClick needs Full Disk Access to work with files in protected directories": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "RClick needs Full Disk Access to work with files in protected directories"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "RClick 需要完全磁盘访问权限才能正常操作受保护目录中的文件"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "RClick が保護されたディレクトリ内のファイルを操作するにはフルディスクアクセスが必要です"
+          }
+        }
+      }
+    },
+    "RClick needs permission to install the update into your Applications folder.": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "RClick needs permission to install the update into your Applications folder."
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "RClick 需要权限以将更新安装到您的“应用程序”文件夹中。"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "RClick がアップデートをアプリケーションフォルダにインストールするには権限が必要です。"
+          }
+        }
+      }
+    },
+    "Reset All Settings?": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Reset All Settings?"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "重置所有设置？"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "すべての設定をリセットしますか？"
+          }
+        }
+      }
+    },
+    "Reset All Settings…": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Reset All Settings…"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "重置所有设置…"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "すべての設定をリセット…"
+          }
+        }
+      }
+    },
+    "Resetting all settings restores the default configuration and cannot be undone": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Resetting all settings restores the default configuration and cannot be undone"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "重置所有设置将恢复默认配置，此操作不可逆"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "すべての設定をリセットすると既定値に戻り、この操作は元に戻せません"
+          }
+        }
+      }
+    },
+    "Restart Later": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Restart Later"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "稍后重启"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "あとで再起動"
+          }
+        }
+      }
+    },
+    "Restart Now": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Restart Now"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "立即重启"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "今すぐ再起動"
+          }
+        }
+      }
+    },
+    "Restore Defaults": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Restore Defaults"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "恢复默认"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "デフォルトに戻す"
+          }
+        }
+      }
+    },
+    "Run Arguments": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Run Arguments"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "运行参数"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "実行引数"
+          }
+        }
+      }
+    },
+    "SF Symbol Name": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "SF Symbol Name"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "SF Symbol 名称"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "SF Symbol 名"
+          }
+        }
+      }
+    },
+    "Separate multiple arguments with semicolons (;)": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Separate multiple arguments with semicolons (;)"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "多个参数用分号（;）分隔"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "複数の引数はセミコロン（;）で区切ってください"
+          }
+        }
+      }
+    },
+    "Settings Management": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Settings Management"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "设置管理"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "設定管理"
+          }
+        }
+      }
+    },
+    "Settings…": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Settings…"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "设置…"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "設定…"
+          }
+        }
+      }
+    },
+    "Show icon in menu bar": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Show icon in menu bar"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "在菜单栏显示图标"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "メニューバーにアイコンを表示"
+          }
+        }
+      }
+    },
+    "Simplified Chinese": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Simplified Chinese"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "简体中文"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "简体中文"
+          }
+        }
+      }
+    },
+    "Template": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Template"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "模板"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "テンプレート"
+          }
+        }
+      }
+    },
+    "The application bundle is invalid or damaged.": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "The application bundle is invalid or damaged."
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "应用程序包无效或损坏。"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "アプリケーションバンドルが無効または破損しています。"
+          }
+        }
+      }
+    },
+    "The application has been updated successfully. Restart the app to finish the update.": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "The application has been updated successfully. Restart the app to finish the update."
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "应用程序已成功更新。需要重启应用来完成更新过程。"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "アプリケーションは正常に更新されました。更新を完了するにはアプリを再起動してください。"
+          }
+        }
+      }
+    },
+    "The current folder cannot be deleted. Please select files or subfolders instead.": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "The current folder cannot be deleted. Please select files or subfolders instead."
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "无法删除当前文件夹，请选择文件或子文件夹进行删除。"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "現在のフォルダは削除できません。代わりにファイルまたはサブフォルダを選択してください。"
+          }
+        }
+      }
+    },
+    "The current folder cannot be shared. Please select files or subfolders instead.": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "The current folder cannot be shared. Please select files or subfolders instead."
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "无法共享当前文件夹，请选择文件或子文件夹进行共享。"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "現在のフォルダは共有できません。代わりにファイルまたはサブフォルダを選択してください。"
+          }
+        }
+      }
+    },
+    "The current version is already up to date.": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "The current version is already up to date."
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "当前版本已是最新，无需更新。"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "現在のバージョンはすでに最新です。"
+          }
+        }
+      }
+    },
+    "The selected folder is a subfolder of an already selected folder. Please choose a different folder.": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "The selected folder is a subfolder of an already selected folder. Please choose a different folder."
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "所选文件夹是已选文件夹的子目录，请选择其他文件夹。"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "選択したフォルダは既に選択済みのフォルダのサブフォルダです。別のフォルダを選択してください。"
+          }
+        }
+      }
+    },
+    "The user cancelled authorization.": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "The user cancelled authorization."
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "用户取消了授权。"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "ユーザーが認証をキャンセルしました。"
+          }
+        }
+      }
+    },
+    "This will delete all custom configurations and restore the defaults. This action cannot be undone.": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "This will delete all custom configurations and restore the defaults. This action cannot be undone."
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "此操作将删除所有自定义配置，恢复到默认状态。此操作不可逆。"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "この操作によりすべてのカスタム設定が削除され、既定値に戻ります。元に戻すことはできません。"
+          }
+        }
+      }
+    },
+    "Unauthorized Folder": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Unauthorized Folder"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "未授权文件夹"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "未承認のフォルダ"
+          }
+        }
+      }
+    },
+    "Unknown": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Unknown"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "未知"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "不明"
+          }
+        }
+      }
+    },
+    "Up to Date": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Up to Date"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "已是最新版本"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "最新です"
+          }
+        }
+      }
+    },
+    "Update Installed": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Update Installed"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "更新安装完成"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "アップデートがインストールされました"
+          }
+        }
+      }
+    },
+    "Version %@": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Version %@"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "版本 %@"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "バージョン %@"
+          }
+        }
+      }
+    },
+    "Version %@ is ignored": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Version %@ is ignored"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "已忽略版本 %@"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "バージョン %@ は無視されています"
+          }
+        }
+      }
+    },
+    "Warning": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Warning"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "警告"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "警告"
+          }
+        }
+      }
     }
   },
-  "version" : "1.0"
+  "version": "1.0"
 }

--- a/RClick/MenuBarView.swift
+++ b/RClick/MenuBarView.swift
@@ -17,13 +17,13 @@ struct MenuBarView: View {
         VStack {
             Button(action: actionSettings) {
                 Image(systemName: "gearshape")
-                Text("Settings")
+                Text(appLocalized: "Settings")
             }
             .keyboardShortcut(",", modifiers: [.command])
 
             Button(action: actionQuit) {
                 Image(systemName: "xmark.square")
-                Text("Quit")
+                Text(appLocalized: "Quit")
             }
             .keyboardShortcut("q", modifiers: [.command])
         }

--- a/RClick/RClickApp.swift
+++ b/RClick/RClickApp.swift
@@ -42,6 +42,7 @@ struct RClickApp: App {
         SettingsWindow(appState: appState, onAppear: {})
             .defaultAppStorage(.group)
             .environmentObject(updateManager)
+            .environment(\.locale, appState.locale)
             .modelContainer(SharedDataManager.sharedModelContainer)
 
         // showMenuBarExtra 为 true 时显示菜单条
@@ -49,7 +50,9 @@ struct RClickApp: App {
             "RClick", image: "MenuBar", isInserted: $showMenuBarExtra
         ) {
             MenuBarView()
-        }.defaultAppStorage(.group)
+        }
+        .defaultAppStorage(.group)
+        .environment(\.locale, appState.locale)
     }
 }
 
@@ -191,7 +194,7 @@ class AppDelegate: NSObject, NSApplicationDelegate {
         let actionMenuItems = appState.actions.filter(\.enabled).map { $0.toActionMenuItem() }
         let appMenuItems = appState.apps.map { $0.toAppMenuItem() }
         let newFileMenuItems = appState.newFiles.map { NewFileMenuItem(id: $0.id, name: $0.name, ext: $0.ext, icon: $0.icon) }
-        let commonDirMenuItems = appState.showCommonDirs ? appState.cdirs.map { CommonDirMenuItem(id: $0.id, name: $0.name, icon: $0.icon, url: $0.url.path) } : []
+        let commonDirMenuItems = appState.showCommonDirs ? appState.cdirs.map { CommonDirMenuItem(id: $0.id, name: $0.displayName, icon: $0.icon, url: $0.url.path) } : []
 
         // 更新版本号
         menuVersion += 1
@@ -280,12 +283,12 @@ class AppDelegate: NSObject, NSApplicationDelegate {
         Task { @MainActor in
             try? await Task.sleep(for: .seconds(2))
             let alert = NSAlert()
-            alert.messageText = String(localized: "Enable Full Disk Access")
-            alert.informativeText = String(localized: "RClick needs Full Disk Access to create files, delete files, and manage hidden files in protected folders (like Desktop, Documents, and Downloads).\n\nWithout this permission, some operations may fail on protected directories.\n\nTo enable:\n1. Click \"Open Settings\" below\n2. Click the lock icon and authenticate\n3. Click \"+\" and add RClick from your Applications folder\n4. Toggle the switch next to RClick to ON")
+            alert.messageText = AppLocalization.localized("Enable Full Disk Access")
+            alert.informativeText = AppLocalization.localized("RClick needs Full Disk Access to create files, delete files, and manage hidden files in protected folders (like Desktop, Documents, and Downloads).\n\nWithout this permission, some operations may fail on protected directories.\n\nTo enable:\n1. Click \"Open Settings\" below\n2. Click the lock icon and authenticate\n3. Click \"+\" and add RClick from your Applications folder\n4. Toggle the switch next to RClick to ON")
             alert.alertStyle = .informational
-            alert.addButton(withTitle: String(localized: "Open Settings"))
-            alert.addButton(withTitle: String(localized: "Later"))
-            alert.addButton(withTitle: String(localized: "Don't Ask Again"))
+            alert.addButton(withTitle: AppLocalization.localized("Open Settings"))
+            alert.addButton(withTitle: AppLocalization.localized("Later"))
+            alert.addButton(withTitle: AppLocalization.localized("Don't Ask Again"))
 
             let response = alert.runModal()
             switch response {
@@ -377,7 +380,7 @@ class AppDelegate: NSObject, NSApplicationDelegate {
     func getUniqueFilePath(dir: String, ext: String) -> String {
         let fileManager = FileManager.default
         let dirURL = URL(fileURLWithPath: dir.hasSuffix("/") ? String(dir.dropLast()) : dir)
-        let baseFileName = String(localized: "Untitled")
+        let baseFileName = AppLocalization.localized("Untitled")
         var filePath = dirURL.appendingPathComponent("\(baseFileName)\(ext)").path
         var counter = 1
 
@@ -419,10 +422,10 @@ class AppDelegate: NSObject, NSApplicationDelegate {
 
         if trigger == "ctx-container" {
             let alert = NSAlert()
-            alert.messageText = "警告"
-            alert.informativeText = "无法共享当前文件夹，请选择文件或子文件夹进行共享。"
+            alert.messageText = AppLocalization.localized("Warning")
+            alert.informativeText = AppLocalization.localized("The current folder cannot be shared. Please select files or subfolders instead.")
             alert.alertStyle = .warning
-            alert.addButton(withTitle: "确定")
+            alert.addButton(withTitle: AppLocalization.localized("OK"))
             alert.runModal()
             return
         }
@@ -433,10 +436,10 @@ class AppDelegate: NSObject, NSApplicationDelegate {
 
             if Utils.isProtectedFolder(decodedPath) {
                 let alert = NSAlert()
-                alert.messageText = "警告"
-                alert.informativeText = "无法分享系统保护文件夹：\(decodedPath)"
+                alert.messageText = AppLocalization.localized("Warning")
+                alert.informativeText = String(format: AppLocalization.localized("Protected system folders cannot be shared: %@"), decodedPath)
                 alert.alertStyle = .warning
-                alert.addButton(withTitle: "确定")
+                alert.addButton(withTitle: AppLocalization.localized("OK"))
                 alert.runModal()
                 logger.warning("试图分享受保护的系统文件夹，操作已被阻止：\(decodedPath)")
                 continue
@@ -447,10 +450,10 @@ class AppDelegate: NSObject, NSApplicationDelegate {
                 if isDir.boolValue {
                     logger.warning("不能通过 AirDrop 分享文件夹：\(decodedPath)")
                     let alert = NSAlert()
-                    alert.messageText = "提示"
-                    alert.informativeText = "不能通过 AirDrop 分享文件夹：\(decodedPath)"
+                    alert.messageText = AppLocalization.localized("Notice")
+                    alert.informativeText = String(format: AppLocalization.localized("Folders cannot be shared via AirDrop: %@"), decodedPath)
                     alert.alertStyle = .informational
-                    alert.addButton(withTitle: "确定")
+                    alert.addButton(withTitle: AppLocalization.localized("OK"))
                     alert.runModal()
                     continue
                 } else {
@@ -570,10 +573,10 @@ class AppDelegate: NSObject, NSApplicationDelegate {
 
         if trigger == "ctx-container" {
             let alert = NSAlert()
-            alert.messageText = "警告"
-            alert.informativeText = "无法删除当前文件夹，请选择文件或子文件夹进行删除。"
+            alert.messageText = AppLocalization.localized("Warning")
+            alert.informativeText = AppLocalization.localized("The current folder cannot be deleted. Please select files or subfolders instead.")
             alert.alertStyle = .warning
-            alert.addButton(withTitle: "确定")
+            alert.addButton(withTitle: AppLocalization.localized("OK"))
             alert.runModal()
             return
         }
@@ -583,10 +586,10 @@ class AppDelegate: NSObject, NSApplicationDelegate {
 
             if Utils.isProtectedFolder(decodedPath) {
                 let alert = NSAlert()
-                alert.messageText = "警告"
-                alert.informativeText = "无法删除系统保护文件夹：\(decodedPath)"
+                alert.messageText = AppLocalization.localized("Warning")
+                alert.informativeText = String(format: AppLocalization.localized("Protected system folders cannot be deleted: %@"), decodedPath)
                 alert.alertStyle = .warning
-                alert.addButton(withTitle: "确定")
+                alert.addButton(withTitle: AppLocalization.localized("OK"))
                 alert.runModal()
                 logger.warning("试图删除受保护的系统文件夹，操作已被阻止：\(decodedPath)")
                 continue

--- a/RClick/Settings/AboutSettingsTabView.swift
+++ b/RClick/Settings/AboutSettingsTabView.swift
@@ -25,7 +25,7 @@ struct AboutSettingsTabView: View {
 
                     VStack(spacing: 4) {
                         Text("RClick").font(.title)
-                        Text("Version \(getAppVersion()) (\(getBuildVersion()))")
+                        Text(String(format: AppLocalization.localized("Version %@ (%@)"), getAppVersion(), getBuildVersion()))
                             .foregroundColor(.secondary)
                     }
                 }
@@ -34,13 +34,13 @@ struct AboutSettingsTabView: View {
             }
 
             Section {
-                Text("RClick is a right-click menu extension that allows you to add applications for opening folders and includes some common actions.")
+                Text(appLocalized: "RClick is a right-click menu extension that allows you to add applications for opening folders and includes some common actions.")
                     .font(.body)
             }
 
             Section {
                 HStack {
-                    Button("检查更新") {
+                    Button(AppLocalization.localized("Check for Updates")) {
                         Task {
                             await updateManager.checkForUpdates(force: true)
                         }
@@ -65,14 +65,14 @@ struct AboutSettingsTabView: View {
         if let version = Bundle.main.infoDictionary?["CFBundleShortVersionString"] as? String {
             return version
         }
-        return "Unknown"
+        return AppLocalization.localized("Unknown")
     }
 
     func getBuildVersion() -> String {
         if let buildVersion = Bundle.main.infoDictionary?["CFBundleVersion"] as? String {
             return buildVersion
         }
-        return "Unknown"
+        return AppLocalization.localized("Unknown")
     }
 }
 

--- a/RClick/Settings/ActionSettingsTabView.swift
+++ b/RClick/Settings/ActionSettingsTabView.swift
@@ -15,14 +15,16 @@ struct ActionSettingsTabView: View {
     var body: some View {
         Form {
             Section {
-                Toggle("折叠动作菜单", isOn: $appState.foldActionsMenu)
+                Toggle(isOn: $appState.foldActionsMenu) {
+                    Text(appLocalized: "Collapse actions menu")
+                }
                     .onChange(of: appState.foldActionsMenu) {
                         NotificationCenter.default.post(name: .menuConfigShouldUpdate, object: nil)
                     }
 
                 ForEach($appState.actions) { $item in
                     LabeledContent {
-                        Toggle("启用", isOn: $item.enabled)
+                        Toggle(AppLocalization.localized("Enabled"), isOn: $item.enabled)
                             .toggleStyle(.switch)
                             .onChange(of: item.enabled) {
                                 appState.toggleActionItem()
@@ -30,13 +32,13 @@ struct ActionSettingsTabView: View {
                             }
                             .labelsHidden()
                     } label: {
-                        Label(LocalizedStringKey(item.name), systemImage: item.icon)
+                        Label(item.displayName, systemImage: item.icon)
                     }
                 }
             } footer: {
                 HStack {
                     Spacer()
-                    Button("恢复到默认设置") {
+                    Button(AppLocalization.localized("Restore Defaults")) {
                         appState.resetActionItems()
                     }
                 }

--- a/RClick/Settings/AppsSettingsTabView.swift
+++ b/RClick/Settings/AppsSettingsTabView.swift
@@ -21,7 +21,9 @@ struct AppsSettingsTabView: View {
     var body: some View {
         Form {
             Section {
-                Toggle("折叠应用菜单", isOn: $appState.foldAppsMenu)
+                Toggle(isOn: $appState.foldAppsMenu) {
+                    Text(appLocalized: "Collapse apps menu")
+                }
                     .onChange(of: appState.foldAppsMenu) {
                         NotificationCenter.default.post(name: .menuConfigShouldUpdate, object: nil)
                     }
@@ -33,7 +35,7 @@ struct AppsSettingsTabView: View {
                     Button {
                         showSelectApp = true
                     } label: {
-                        Label("添加应用", systemImage: "plus.app")
+                        Label(AppLocalization.localized("Add App"), systemImage: "plus.app")
                     }
                 }
 
@@ -46,7 +48,7 @@ struct AppsSettingsTabView: View {
                                 Image(systemName: "pencil")
                             }
                             .buttonStyle(.borderless)
-                            .help("编辑应用")
+                            .help(AppLocalization.localized("Edit App"))
 
                             Button {
                                 deleteApp(item)
@@ -54,7 +56,7 @@ struct AppsSettingsTabView: View {
                                 Image(systemName: "trash")
                             }
                             .buttonStyle(.borderless)
-                            .help("删除应用")
+                            .help(AppLocalization.localized("Delete App"))
                         }
                     } label: {
                         HStack(spacing: 8) {
@@ -98,10 +100,10 @@ struct AppsSettingsTabView: View {
     private func appSummary(_ item: OpenWithApp) -> String {
         var parts: [String] = []
         if !item.arguments.isEmpty {
-            parts.append("参数: \(item.arguments.joined(separator: "; "))")
+            parts.append(String(format: AppLocalization.localized("Arguments: %@"), item.arguments.joined(separator: "; ")))
         }
         if !item.environment.isEmpty {
-            parts.append("环境变量: \(item.environment.count)个")
+            parts.append(String(format: AppLocalization.localized("Environment variables: %lld"), Int64(item.environment.count)))
         }
         return parts.joined(separator: " · ")
     }

--- a/RClick/Settings/CommonDirsSettingTabView.swift
+++ b/RClick/Settings/CommonDirsSettingTabView.swift
@@ -24,11 +24,15 @@ struct CommonDirsSettingTabView: View {
     var body: some View {
         Form {
             Section {
-                Toggle("启用常用文件夹", isOn: $store.showCommonDirs)
+                Toggle(isOn: $store.showCommonDirs) {
+                    Text(appLocalized: "Enable common folders")
+                }
                     .onChange(of: store.showCommonDirs) {
                         NotificationCenter.default.post(name: .menuConfigShouldUpdate, object: nil)
                     }
-                Toggle("折叠菜单", isOn: $store.foldCommonDirMenu)
+                Toggle(isOn: $store.foldCommonDirMenu) {
+                    Text(appLocalized: "Collapse menu")
+                }
                     .disabled(!store.showCommonDirs)
                     .onChange(of: store.foldCommonDirMenu) {
                         NotificationCenter.default.post(name: .menuConfigShouldUpdate, object: nil)
@@ -41,7 +45,7 @@ struct CommonDirsSettingTabView: View {
                     Button {
                         showCommonDirImporter = true
                     } label: {
-                        Label("添加文件夹", systemImage: "folder.badge.plus")
+                        Label(AppLocalization.localized("Add Folder"), systemImage: "folder.badge.plus")
                     }
                 }
 
@@ -54,11 +58,11 @@ struct CommonDirsSettingTabView: View {
                         }
                         .buttonStyle(.borderless)
                     } label: {
-                        Label(item.url.lastPathComponent, systemImage: item.icon.isEmpty ? "folder" : item.icon)
+                        Label(item.displayName, systemImage: item.icon.isEmpty ? "folder" : item.icon)
                     }
                 }
             } header: {
-                Text("已添加的文件夹")
+                Text(appLocalized: "Added Folders")
             }
         }
         .formStyle(.grouped)

--- a/RClick/Settings/EditAppSheetView.swift
+++ b/RClick/Settings/EditAppSheetView.swift
@@ -29,26 +29,26 @@ struct EditAppSheetView: View {
 
     var body: some View {
         VStack(spacing: 0) {
-            Text("编辑应用属性")
+            Text(appLocalized: "Edit App Properties")
                 .font(.headline)
                 .padding(.top, 20)
                 .padding(.bottom, 12)
 
             Form {
                 Section {
-                    TextField("显示名称", text: $itemName)
+                    TextField(AppLocalization.localized("Display Name"), text: $itemName)
                         .textFieldStyle(.roundedBorder)
                 } header: {
-                    Text("显示名称")
+                    Text(appLocalized: "Display Name")
                 }
 
                 Section {
-                    TextField("参数（分号分隔）", text: $arguments)
+                    TextField(AppLocalization.localized("Arguments (semicolon separated)"), text: $arguments)
                         .textFieldStyle(.roundedBorder)
                 } header: {
-                    Text("运行参数")
+                    Text(appLocalized: "Run Arguments")
                 } footer: {
-                    Text("多个参数用分号（;）分隔")
+                    Text(appLocalized: "Separate multiple arguments with semicolons (;)")
                         .foregroundColor(.secondary)
                 }
 
@@ -58,21 +58,21 @@ struct EditAppSheetView: View {
                         .frame(height: 100)
                         .border(Color.gray.opacity(0.2))
                 } header: {
-                    Text("环境变量")
+                    Text(appLocalized: "Environment Variables")
                 } footer: {
-                    Text("格式：KEY=VALUE，每行一个")
+                    Text(appLocalized: "Format: KEY=VALUE, one per line")
                         .foregroundColor(.secondary)
                 }
             }
             .formStyle(.grouped)
 
             HStack {
-                Button("取消") {
+                Button(AppLocalization.localized("Cancel")) {
                     dismiss()
                 }
                 .keyboardShortcut(.escape)
 
-                Button("保存") {
+                Button(AppLocalization.localized("Save")) {
                     saveChanges()
                     dismiss()
                 }

--- a/RClick/Settings/EditFileTypeSheetView.swift
+++ b/RClick/Settings/EditFileTypeSheetView.swift
@@ -52,26 +52,26 @@ struct EditFileTypeSheetView: View {
 
     var body: some View {
         VStack(spacing: 0) {
-            Text(isAdding ? "添加文件类型" : "编辑文件类型")
+            Text(appLocalized: isAdding ? "Add File Type" : "Edit File Type")
                 .font(.headline)
                 .padding(.top, 20)
                 .padding(.bottom, 12)
 
             Form {
                 Section {
-                    TextField("显示名称", text: $name)
+                    TextField(AppLocalization.localized("Display Name"), text: $name)
                         .textFieldStyle(.roundedBorder)
                 } header: {
-                    Text("名称")
+                    Text(appLocalized: "Name")
                 }
 
                 Section {
-                    TextField("文件扩展名", text: $ext)
+                    TextField(AppLocalization.localized("File Extension"), text: $ext)
                         .textFieldStyle(.roundedBorder)
                 } header: {
-                    Text("扩展名")
+                    Text(appLocalized: "File Extension")
                 } footer: {
-                    Text("例如：txt、md、json")
+                    Text(appLocalized: "For example: txt, md, json")
                         .foregroundColor(.secondary)
                 }
 
@@ -89,7 +89,7 @@ struct EditFileTypeSheetView: View {
                         Button {
                             showSelectTemplate = true
                         } label: {
-                            Text(template == nil ? "选择模板文件" : "更换模板")
+                            Text(appLocalized: template == nil ? "Choose Template File" : "Change Template")
                         }
                         .fileImporter(
                             isPresented: $showSelectTemplate,
@@ -107,16 +107,16 @@ struct EditFileTypeSheetView: View {
                         }
                     }
                 } header: {
-                    Text("模板")
+                    Text(appLocalized: "Template")
                 }
 
                 Section {
-                    TextField("SF Symbol 名称", text: $icon)
+                    TextField(AppLocalization.localized("SF Symbol Name"), text: $icon)
                         .textFieldStyle(.roundedBorder)
 
                     if !icon.isEmpty {
                         HStack {
-                            Text("预览:")
+                            Text(appLocalized: "Preview:")
                             if let preview = FileTypeIconProvider.shared.icon(for: ext, fallbackSymbol: icon) {
                                 Image(nsImage: preview)
                                     .resizable()
@@ -129,9 +129,9 @@ struct EditFileTypeSheetView: View {
                         }
                     }
                 } header: {
-                    Text("图标")
+                    Text(appLocalized: "Icon")
                 } footer: {
-                    Text("输入 SF Symbol 名称，例如 doc.text、curlybraces")
+                    Text(appLocalized: "Enter an SF Symbol name, for example doc.text or curlybraces")
                         .foregroundColor(.secondary)
                 }
 
@@ -147,7 +147,7 @@ struct EditFileTypeSheetView: View {
                         Button {
                             showSelectApp = true
                         } label: {
-                            Text(openApp == nil ? "选择默认打开应用" : "更换应用")
+                            Text(appLocalized: openApp == nil ? "Choose Default App" : "Change App")
                         }
                         .fileImporter(
                             isPresented: $showSelectApp,
@@ -174,18 +174,18 @@ struct EditFileTypeSheetView: View {
                         }
                     }
                 } header: {
-                    Text("默认打开应用")
+                    Text(appLocalized: "Default Open App")
                 }
             }
             .formStyle(.grouped)
 
             HStack {
-                Button("取消") {
+                Button(AppLocalization.localized("Cancel")) {
                     dismiss()
                 }
                 .keyboardShortcut(.escape)
 
-                Button(isAdding ? "添加" : "保存") {
+                Button(AppLocalization.localized(isAdding ? "Add" : "Save")) {
                     saveChanges()
                     dismiss()
                 }

--- a/RClick/Settings/GeneralSettingsTabView.swift
+++ b/RClick/Settings/GeneralSettingsTabView.swift
@@ -35,7 +35,7 @@ struct GeneralSettingsTabView: View {
         Form {
             // MARK: - 第一组：主要控制
             Section {
-                Toggle("启用 RClick", isOn: Binding(
+                Toggle(isOn: Binding(
                     get: { finderSyncStatus == .enabled },
                     set: { newValue in
                         if newValue {
@@ -48,15 +48,33 @@ struct GeneralSettingsTabView: View {
                             openFileProviderSettings()
                         }
                     }
-                ))
+                )) {
+                    Text(appLocalized: "Enable RClick")
+                }
 
-                Toggle("在菜单栏显示图标", isOn: $showMenuBarExtra)
+                Toggle(isOn: $showMenuBarExtra) {
+                    Text(appLocalized: "Show icon in menu bar")
+                }
 
-                Toggle("登录时启动", isOn: $launchAtLogin)
+                Toggle(isOn: $launchAtLogin) {
+                    Text(appLocalized: "Launch at login")
+                }
+
+                Picker(selection: Binding(
+                    get: { store.selectedLanguage },
+                    set: { store.selectedLanguage = $0 }
+                )) {
+                    Text(appLocalized: "Automatic").tag(AppLanguage.automatic)
+                    Text(appLocalized: "Simplified Chinese").tag(AppLanguage.simplifiedChinese)
+                    Text(appLocalized: "English").tag(AppLanguage.english)
+                    Text(appLocalized: "Japanese").tag(AppLanguage.japanese)
+                } label: {
+                    Text(appLocalized: "Language")
+                }
             } header: {
-                Text("主要控制")
+                Text(appLocalized: "Main Controls")
             } footer: {
-                Text("在文件提供程序中启用 RClick 以在右键菜单中显示功能")
+                Text(appLocalized: "Enable RClick in File Provider to show its actions in Finder context menus")
             }
 
             // MARK: - 第二组：权限
@@ -66,45 +84,45 @@ struct GeneralSettingsTabView: View {
                     Text(finderSyncStatus.description)
                         .foregroundColor(.secondary)
                 } label: {
-                    Label("Finder 扩展", systemImage: finderSyncStatus.icon)
+                    Label(AppLocalization.localized("Finder Extension"), systemImage: finderSyncStatus.icon)
                         .foregroundColor(finderSyncStatus.color)
                 }
 
                 // 完全磁盘访问权限
                 LabeledContent {
-                    Button("设置…") {
+                    Button(AppLocalization.localized("Settings…")) {
                         openFullDiskAccessSettings()
                     }
                 } label: {
-                    Label("完全磁盘访问权限", systemImage: fullDiskAccessStatus.icon)
+                    Label(AppLocalization.localized("Full Disk Access"), systemImage: fullDiskAccessStatus.icon)
                         .foregroundColor(fullDiskAccessStatus.color)
                 }
 
                 // 辅助功能权限
                 LabeledContent {
-                    Button("设置…") {
+                    Button(AppLocalization.localized("Settings…")) {
                         openAccessibilitySettings()
                     }
                 } label: {
-                    Label("辅助功能", systemImage: accessibilityStatus.icon)
+                    Label(AppLocalization.localized("Accessibility"), systemImage: accessibilityStatus.icon)
                         .foregroundColor(accessibilityStatus.color)
                 }
             } header: {
-                Text("权限")
+                Text(appLocalized: "Permissions")
             } footer: {
                 VStack(alignment: .leading, spacing: 4) {
-                    Text("文件提供程序：在列表中选择「RClick」以启用 Finder 右键菜单")
+                    Text(appLocalized: "File Provider: Select \"RClick\" in the list to enable the Finder context menu")
                         .foregroundColor(.secondary)
-                    Text("完全磁盘访问权限：用于在受保护目录中创建和删除文件")
+                    Text(appLocalized: "Full Disk Access: Required to create and delete files in protected directories")
                         .foregroundColor(.secondary)
                     if fullDiskAccessStatus != .enabled {
                         VStack(alignment: .leading, spacing: 4) {
-                            Text("RClick 需要完全磁盘访问权限才能正常操作受保护目录中的文件")
+                            Text(appLocalized: "RClick needs Full Disk Access to work with files in protected directories")
                                 .fontWeight(.medium)
-                            Text("1. 点击右侧「设置…」按钮打开系统设置")
-                            Text("2. 点击左下角锁图标并认证")
-                            Text("3. 点击「+」→ 前往「应用程序」→ 选择「RClick」")
-                            Text("4. 确保 RClick 旁边的开关已打开")
+                            Text(appLocalized: "1. Click \"Settings…\" on the right to open System Settings")
+                            Text(appLocalized: "2. Click the lock icon and authenticate")
+                            Text(appLocalized: "3. Click \"+\" -> open \"Applications\" -> select \"RClick\"")
+                            Text(appLocalized: "4. Make sure the switch next to RClick is turned on")
                         }
                         .font(.caption)
                         .foregroundColor(.secondary)
@@ -117,38 +135,38 @@ struct GeneralSettingsTabView: View {
                 // 备份
                 LabeledContent {
                     HStack(spacing: 12) {
-                        Button("导出…") {
+                        Button(AppLocalization.localized("Export…")) {
                             exportSettings()
                         }
-                        Button("导入…") {
+                        Button(AppLocalization.localized("Import…")) {
                             importSettings()
                         }
                     }
                 } label: {
-                    Text("备份")
+                    Text(appLocalized: "Backup")
                 }
 
                 // 日志
                 LabeledContent {
-                    Button("导出日志…") {
+                    Button(AppLocalization.localized("Export Logs…")) {
                         exportLogs()
                     }
                 } label: {
-                    Text("日志")
+                    Text(appLocalized: "Logs")
                 }
 
                 // 重置所有设置
                 HStack {
                     Spacer()
-                    Button("重置所有设置…") {
+                    Button(AppLocalization.localized("Reset All Settings…")) {
                         resetAllSettings()
                     }
                     .foregroundColor(.red)
                 }
             } header: {
-                Text("设置管理")
+                Text(appLocalized: "Settings Management")
             } footer: {
-                Text("重置所有设置将恢复默认配置，此操作不可逆")
+                Text(appLocalized: "Resetting all settings restores the default configuration and cannot be undone")
             }
         }
         .formStyle(.grouped)
@@ -159,24 +177,24 @@ struct GeneralSettingsTabView: View {
             updatePermissionStatus()
         }
         .alert(
-            Text("无效文件夹"),
+            Text(appLocalized: "Invalid Folder"),
             isPresented: $wrongFold
         ) {
-            Button("确定") {
+            Button(AppLocalization.localized("OK")) {
                 showDirImporter = true
             }
         } message: {
-            Text("所选文件夹是已选文件夹的子目录，请选择其他文件夹。")
+            Text(appLocalized: "The selected folder is a subfolder of an already selected folder. Please choose a different folder.")
         }
         .alert(
-            Text("未授权文件夹"),
+            Text(appLocalized: "Unauthorized Folder"),
             isPresented: $showAlert
         ) {
-            Button("确定") {
+            Button(AppLocalization.localized("OK")) {
                 showDirImporter = true
             }
         } message: {
-            Text("必须授予文件夹访问权限才能使用此功能。")
+            Text(appLocalized: "Folder access permission is required to use this feature.")
         }
     }
 
@@ -256,11 +274,11 @@ struct GeneralSettingsTabView: View {
 
     private func resetAllSettings() {
         let alert = NSAlert()
-        alert.messageText = "重置所有设置？"
-        alert.informativeText = "此操作将删除所有自定义配置，恢复到默认状态。此操作不可逆。"
+        alert.messageText = AppLocalization.localized("Reset All Settings?")
+        alert.informativeText = AppLocalization.localized("This will delete all custom configurations and restore the defaults. This action cannot be undone.")
         alert.alertStyle = .warning
-        alert.addButton(withTitle: "重置")
-        alert.addButton(withTitle: "取消")
+        alert.addButton(withTitle: AppLocalization.localized("Reset"))
+        alert.addButton(withTitle: AppLocalization.localized("Cancel"))
         alert.buttons[0].hasDestructiveAction = true
 
         let response = alert.runModal()
@@ -303,11 +321,11 @@ enum PermissionStatus {
     var description: String {
         switch self {
         case .enabled:
-            return "已授权"
+            return AppLocalization.localized("Authorized")
         case .disabled:
-            return "未授权"
+            return AppLocalization.localized("Not Authorized")
         case .unknown:
-            return "未知"
+            return AppLocalization.localized("Unknown")
         }
     }
 }

--- a/RClick/Settings/NewFileSettingsTabView.swift
+++ b/RClick/Settings/NewFileSettingsTabView.swift
@@ -23,7 +23,9 @@ struct NewFileSettingsTabView: View {
     var body: some View {
         Form {
             Section {
-                Toggle("折叠新建文件菜单", isOn: $appState.foldNewFileMenu)
+                Toggle(isOn: $appState.foldNewFileMenu) {
+                    Text(appLocalized: "Collapse new file menu")
+                }
                     .onChange(of: appState.foldNewFileMenu) {
                         NotificationCenter.default.post(name: .menuConfigShouldUpdate, object: nil)
                     }
@@ -35,13 +37,13 @@ struct NewFileSettingsTabView: View {
                     Button {
                         appState.resetFiletypeItems()
                     } label: {
-                        Label("恢复默认", systemImage: "arrow.triangle.2.circlepath")
+                        Label(AppLocalization.localized("Restore Defaults"), systemImage: "arrow.triangle.2.circlepath")
                     }
                     Spacer()
                     Button {
                         editingFile = NewFile(ext: "", name: "", idx: appState.newFiles.count)
                     } label: {
-                        Label("添加文件类型", systemImage: "plus")
+                        Label(AppLocalization.localized("Add File Type"), systemImage: "plus")
                     }
                 }
 
@@ -54,9 +56,9 @@ struct NewFileSettingsTabView: View {
                                 Image(systemName: "pencil")
                             }
                             .buttonStyle(.borderless)
-                            .help("编辑文件类型")
+                            .help(AppLocalization.localized("Edit File Type"))
 
-                            Toggle("启用", isOn: $item.enabled)
+                            Toggle(AppLocalization.localized("Enabled"), isOn: $item.enabled)
                                 .toggleStyle(.switch)
                                 .onChange(of: item.enabled) {
                                     appState.toggleActionItem()
@@ -81,7 +83,7 @@ struct NewFileSettingsTabView: View {
 
                             VStack(alignment: .leading, spacing: 2) {
                                 Text(item.name)
-                                Text("扩展名: \(item.ext)")
+                                Text(String(format: AppLocalization.localized("Extension: %@"), item.ext))
                                     .font(.caption)
                                     .foregroundColor(.secondary)
                             }

--- a/RClick/Settings/SettingsView.swift
+++ b/RClick/Settings/SettingsView.swift
@@ -38,7 +38,11 @@ struct SettingsView: View {
     private var sidebar: some View {
         List(selection: self.$selectedTab) {
             ForEach(Tabs.allCases, id: \.self) { tab in
-                Label(LocalizedStringKey(tab.rawValue), systemImage: tab.icon)
+                Label {
+                    Text(appLocalized: tab.rawValue)
+                } icon: {
+                    Image(systemName: tab.icon)
+                }
                     .labelStyle(.titleAndIcon)
             }
         }
@@ -102,7 +106,7 @@ struct SettingsView: View {
         if let version = Bundle.main.infoDictionary?["CFBundleShortVersionString"] as? String {
             return version
         }
-        return "Unknown"
+        return AppLocalization.localized("Unknown")
     }
 }
 

--- a/RClick/Settings/SettingsWindow.swift
+++ b/RClick/Settings/SettingsWindow.swift
@@ -15,9 +15,10 @@ struct SettingsWindow: Scene {
     let onAppear: () -> Void
 
     var body: some Scene {
-        Window("Settings", id: Constants.settingsWindowID) {
+        Window(AppLocalization.localized("Settings"), id: Constants.settingsWindowID) {
             SettingsView()
                 .environmentObject(appState)
+                .environment(\.locale, appState.locale)
                 .onAppear {
                     onAppear()
                 }

--- a/RClick/Shared/StringExtension.swift
+++ b/RClick/Shared/StringExtension.swift
@@ -38,6 +38,7 @@ enum Key {
     static let showMenuBarExtra = "showMenuBarExtra"
     static let showInDock = "SHOW_IN_DOCK"
     static let hasSeenFDAGuide = "HAS_SEEN_FDA_GUIDE"
+    static let selectedLanguage = "SELECTED_LANGUAGE"
     static let actionMenuItems = "RCLICK_ACTION_MENU_ITEMS"
     static let appMenuItems = "RCLICK_APP_MENU_ITEMS"
 

--- a/RClick/Shared/Updater.swift
+++ b/RClick/Shared/Updater.swift
@@ -207,14 +207,14 @@ class UpdateManager: ObservableObject {
         
         guard let release = await githubChecker.checkForUpdate(currentVersion: currentVersion) else {
             print("not release")
-            updateError = "当前已经是最新版本"
+            updateError = AppLocalization.localized("The current version is already up to date.")
             return
         }
             
         // 检查用户是否忽略了此版本
         if !force && preferences.isVersionIgnored(release.version) {
             print("忽略这个版本")
-            updateError = "已忽略版本 \(release.version)"
+            updateError = String(format: AppLocalization.localized("Version %@ is ignored"), release.version)
             return
         }
             
@@ -226,14 +226,14 @@ class UpdateManager: ObservableObject {
     func downloadAndInstallUpdate() async {
         print("start downloadAndInstallUpdate")
         guard let release = availableUpdate else {
-            updateError = "没有可用的更新"
+            updateError = AppLocalization.localized("No update is available.")
             print("没有可用的更新")
             return
         }
         
         // 查找 .app.zip 附件
         guard let appZipAsset = release.assets.first(where: { $0.name.lowercased().hasSuffix(".app.zip") }) else {
-            updateError = "未找到 .app.zip 格式的应用程序包"
+            updateError = AppLocalization.localized("No .app.zip application package was found.")
             print("没有可用的更新")
             return
         }
@@ -259,7 +259,7 @@ class UpdateManager: ObservableObject {
             showInstallationCompleteAlert()
             
         } catch {
-            updateError = "安装失败: \(error.localizedDescription)"
+            updateError = String(format: AppLocalization.localized("Installation failed: %@"), error.localizedDescription)
         }
         
         isDownloading = false
@@ -338,7 +338,7 @@ class UpdateManager: ObservableObject {
         guard process.terminationStatus == 0 else {
             let errorData = errorPipe.fileHandleForReading.readDataToEndOfFile()
             let errorString = String(data: errorData, encoding: .utf8) ?? "未知错误"
-            throw InstallationError.zipExtractionFailed("解压失败: \(errorString)")
+            throw InstallationError.zipExtractionFailed(String(format: AppLocalization.localized("Extraction failed: %@"), errorString))
         }
         
         // 查找解压后的 .app 文件
@@ -346,7 +346,7 @@ class UpdateManager: ObservableObject {
         let contents = try fileManager.contentsOfDirectory(at: extractionDir, includingPropertiesForKeys: nil)
         
         guard let appURL = contents.first(where: { $0.pathExtension == "app" }) else {
-            throw InstallationError.noAppFound("在ZIP文件中未找到.app应用程序")
+            throw InstallationError.noAppFound(AppLocalization.localized("No .app application was found in the ZIP file."))
         }
         
         return appURL
@@ -356,8 +356,8 @@ class UpdateManager: ObservableObject {
     @MainActor
     private func requestApplicationsFolderAccess() async throws {
         let openPanel = NSOpenPanel()
-        openPanel.message = "RClick 需要权限以将更新安装到您的“应用程序”文件夹中。"
-        openPanel.prompt = "授予权限"
+        openPanel.message = AppLocalization.localized("RClick needs permission to install the update into your Applications folder.")
+        openPanel.prompt = AppLocalization.localized("Grant Permission")
         openPanel.canChooseFiles = false
         openPanel.canChooseDirectories = true
         openPanel.allowsMultipleSelection = false
@@ -366,13 +366,13 @@ class UpdateManager: ObservableObject {
         let response = await openPanel.begin()
         
         guard response == .OK, let selectedURL = openPanel.url else {
-            throw InstallationError.permissionDenied("用户取消了授权。")
+            throw InstallationError.permissionDenied(AppLocalization.localized("The user cancelled authorization."))
         }
 
         // 验证用户是否选择了正确的文件夹
         let applicationsURL = FileManager.default.urls(for: .applicationDirectory, in: .localDomainMask).first!
         guard selectedURL.path == applicationsURL.path else {
-            throw InstallationError.permissionDenied("请选择正确的‘应用程序’文件夹。")
+            throw InstallationError.permissionDenied(AppLocalization.localized("Please select the correct Applications folder."))
         }
     }
     // MARK: - 安装应用到应用程序目录
@@ -400,7 +400,7 @@ class UpdateManager: ObservableObject {
             // 验证应用程序是否有效
             guard Bundle(url: destinationAppURL) != nil else {
 //                try fileManager.removeItem(at: destinationAppURL)
-                throw InstallationError.invalidAppBundle("应用程序包无效或损坏")
+                throw InstallationError.invalidAppBundle(AppLocalization.localized("The application bundle is invalid or damaged."))
             }
         } catch {
             print("❌ 安装失败: \(error)")
@@ -412,10 +412,10 @@ class UpdateManager: ObservableObject {
 
     private func showInstallationCompleteAlert() {
         let alert = NSAlert()
-        alert.messageText = "更新安装完成"
-        alert.informativeText = "应用程序已成功更新。需要重启应用来完成更新过程。"
-        alert.addButton(withTitle: "立即重启")
-        alert.addButton(withTitle: "稍后重启")
+        alert.messageText = AppLocalization.localized("Update Installed")
+        alert.informativeText = AppLocalization.localized("The application has been updated successfully. Restart the app to finish the update.")
+        alert.addButton(withTitle: AppLocalization.localized("Restart Now"))
+        alert.addButton(withTitle: AppLocalization.localized("Restart Later"))
         
         let response = alert.runModal()
         if response == .alertFirstButtonReturn {

--- a/RClick/Shared/UpdaterView.swift
+++ b/RClick/Shared/UpdaterView.swift
@@ -30,7 +30,7 @@ struct UpdateView: View {
         VStack(spacing: 15) {
             ProgressView()
                 .scaleEffect(1.5)
-            Text("正在检查更新...")
+            Text(appLocalized: "Checking for updates...")
                 .font(.headline)
         }
     }
@@ -42,11 +42,11 @@ struct UpdateView: View {
                 .font(.system(size: 50))
                 .foregroundColor(.blue)
             
-            Text("发现新版本")
+            Text(appLocalized: "New Version Available")
                 .font(.title2)
                 .bold()
             
-            Text("版本 \(release.version)")
+            Text(String(format: AppLocalization.localized("Version %@"), release.version))
                 .font(.title3)
                 .foregroundColor(.secondary)
             
@@ -60,17 +60,17 @@ struct UpdateView: View {
             .cornerRadius(8)
             
             HStack {
-                Button("忽略此版本") {
+                Button(AppLocalization.localized("Ignore This Version")) {
                     updateManager.ignoreCurrentUpdate()
                     updateManager.dismissUpdateSheet()
                 }
                 
-                Button("手动下载") {
+                Button(AppLocalization.localized("Download Manually")) {
                     updateManager.openReleasesPage()
                     updateManager.dismissUpdateSheet()
                 }
                 
-                Button("下载并安装") {
+                Button(AppLocalization.localized("Download and Install")) {
                     Task {
                         await updateManager.downloadAndInstallUpdate()
                     }
@@ -86,14 +86,14 @@ struct UpdateView: View {
                 .font(.system(size: 50))
                 .foregroundColor(.green)
             
-            Text("已是最新版本")
+            Text(appLocalized: "Up to Date")
                 .font(.title2)
                 .bold()
             
-            Text("当前版本已是最新，无需更新。")
+            Text(appLocalized: "The current version is already up to date.")
                 .foregroundColor(.secondary)
             
-            Button("确定") {
+            Button(AppLocalization.localized("OK")) {
                 updateManager.dismissUpdateSheet()
             }
             .buttonStyle(.borderedProminent)
@@ -106,7 +106,7 @@ struct UpdateView: View {
                 .font(.system(size: 50))
                 .foregroundColor(.yellow)
             
-            Text("检查更新失败")
+            Text(appLocalized: "Failed to Check for Updates")
                 .font(.title2)
                 .bold()
             
@@ -114,7 +114,7 @@ struct UpdateView: View {
                 .font(.body)
                 .multilineTextAlignment(.center)
             
-            Button("确定") {
+            Button(AppLocalization.localized("OK")) {
                 updateManager.dismissUpdateSheet()
             }
             .buttonStyle(.bordered)

--- a/Shared/AppLocalization.swift
+++ b/Shared/AppLocalization.swift
@@ -1,0 +1,96 @@
+//
+//  AppLocalization.swift
+//  RClick
+//
+//  Created by Codex on 2026/7/3.
+//
+
+import Foundation
+import SwiftUI
+
+enum AppLanguage: String, CaseIterable, Identifiable {
+    case automatic = "auto"
+    case simplifiedChinese = "zh-Hans"
+    case english = "en"
+    case japanese = "ja"
+
+    var id: String { rawValue }
+
+    var localeIdentifier: String {
+        switch self {
+        case .automatic:
+            AppLocalization.systemLanguage.localeIdentifier
+        case .simplifiedChinese:
+            "zh-Hans"
+        case .english:
+            "en"
+        case .japanese:
+            "ja"
+        }
+    }
+}
+
+enum AppLocalization {
+    static let tableName = "Localizable"
+    private static let selectedLanguageKey = "SELECTED_LANGUAGE"
+    private static var groupDefaults: UserDefaults {
+        UserDefaults(suiteName: "group.cn.wflixu.RClick") ?? .standard
+    }
+
+    static var systemLanguage: AppLanguage {
+        let preferred = Locale.preferredLanguages.first?.lowercased() ?? "en"
+        if preferred.hasPrefix("zh") {
+            return .simplifiedChinese
+        }
+        if preferred.hasPrefix("ja") {
+            return .japanese
+        }
+        return .english
+    }
+
+    static var currentLanguage: AppLanguage {
+        guard let rawValue = groupDefaults.string(forKey: selectedLanguageKey),
+              let language = AppLanguage(rawValue: rawValue)
+        else {
+            return .automatic
+        }
+        return language
+    }
+
+    static var currentLocale: Locale {
+        Locale(identifier: currentLanguage.localeIdentifier)
+    }
+
+    static func localized(_ key: String, bundle: Bundle = .main) -> String {
+        localized(key, tableName: tableName, bundle: bundle)
+    }
+
+    static func localized(_ key: String, tableName: String, bundle: Bundle = .main) -> String {
+        let bundle = localizedBundle(for: bundle)
+        return bundle.localizedString(forKey: key, value: key, table: tableName)
+    }
+
+    private static func localizedBundle(for bundle: Bundle) -> Bundle {
+        let localeIdentifier = currentLanguage.localeIdentifier
+
+        if let path = bundle.path(forResource: localeIdentifier, ofType: "lproj"),
+           let localizedBundle = Bundle(path: path) {
+            return localizedBundle
+        }
+
+        let candidates = Bundle.preferredLocalizations(from: bundle.localizations, forPreferences: [localeIdentifier])
+        if let preferred = candidates.first,
+           let path = bundle.path(forResource: preferred, ofType: "lproj"),
+           let localizedBundle = Bundle(path: path) {
+            return localizedBundle
+        }
+
+        return bundle
+    }
+}
+
+extension Text {
+    init(appLocalized key: String) {
+        self.init(AppLocalization.localized(key))
+    }
+}

--- a/Shared/RCBase.swift
+++ b/Shared/RCBase.swift
@@ -164,6 +164,17 @@ struct CommonDir: @MainActor RCBase {
         self.url = url
         self.icon = icon
     }
+
+    var displayName: String {
+        switch id {
+        case "desktop": return AppLocalization.localized("Desktop")
+        case "documents": return AppLocalization.localized("Documents")
+        case "downloads": return AppLocalization.localized("Downloads")
+        case "applications": return AppLocalization.localized("Applications")
+        case "home": return AppLocalization.localized("Home")
+        default: return name
+        }
+    }
 }
 
 struct RCAction: @MainActor RCBase {
@@ -310,11 +321,11 @@ extension RCAction {
     /// 本地化显示名称
     var displayName: String {
         switch id {
-        case "copy-path": return String(localized: "Copy Path")
-        case "delete-direct": return String(localized: "Delete Direct")
-        case "hide": return String(localized: "Hide")
-        case "unhide": return String(localized: "Unhide")
-        case "airdrop": return String(localized: "AirDrop")
+        case "copy-path": return AppLocalization.localized("Copy Path")
+        case "delete-direct": return AppLocalization.localized("Delete Direct")
+        case "hide": return AppLocalization.localized("Hide")
+        case "unhide": return AppLocalization.localized("Unhide")
+        case "airdrop": return AppLocalization.localized("AirDrop")
         default: return name
         }
     }


### PR DESCRIPTION
## Summary
- Add shared localization support for Simplified Chinese, English, and Japanese.
- Add automatic language detection plus manual language selection in Settings.
- Share the selected language through App Group so the main app and Finder Sync extension stay consistent.
- Localize settings, menu bar actions, Finder context menu sections, updater UI, permission prompts, alerts, and default file names.

## Verification
- Validated all AppText.strings files with plutil.
- Checked there are no remaining hard-coded user-facing Chinese SwiftUI/NSAlert strings.
- Built successfully with: xcodebuild -project RClick.xcodeproj -scheme RClick -configuration Debug -derivedDataPath work/DerivedData-Verify CODE_SIGNING_ALLOWED=NO CODE_SIGNING_REQUIRED=NO build