### PR TITLE
Polish localization handling and add menu ordering

### DIFF
--- a/FinderSyncExt/FinderSyncExt.swift
+++ b/FinderSyncExt/FinderSyncExt.swift
@@ -324,11 +324,15 @@ class FinderSyncExt: FIFinderSync, @unchecked Sendable {
         }
 
         // 构建新建文件菜单
-        if !config.newFiles.isEmpty {
+        do {
             if config.newFilesCollapsed {
                 // 折叠：使用子菜单
                 let newFilesTitle = AppLocalization.localized("New File")
                 let newFilesSubMenu = NSMenu(title: newFilesTitle)
+                newFilesSubMenu.addItem(customNewFileMenuItem())
+                if !config.newFiles.isEmpty {
+                    newFilesSubMenu.addItem(.separator())
+                }
                 for newFile in config.newFiles {
                     let item = NSMenuItem(title: newFile.name, action: #selector(handleNewFileClick(_:)), keyEquivalent: "")
                     item.tag = hashForNewFile(newFile)
@@ -343,6 +347,7 @@ class FinderSyncExt: FIFinderSync, @unchecked Sendable {
                 menu.addItem(newFilesItem)
             } else {
                 // 不折叠：直接显示菜单项
+                menu.addItem(customNewFileMenuItem())
                 for newFile in config.newFiles {
                     let item = NSMenuItem(title: newFile.name, action: #selector(handleNewFileClick(_:)), keyEquivalent: "")
                     item.tag = hashForNewFile(newFile)
@@ -400,8 +405,20 @@ class FinderSyncExt: FIFinderSync, @unchecked Sendable {
         return "newfile_\(newFile.id)".hash
     }
 
+    private func hashForCustomNewFile() -> Int {
+        return "newfile_\(NewFileMenuItem.customFileId)".hash
+    }
+
     private func hashForCommonDir(_ commonDir: CommonDirMenuItem) -> Int {
         return "commondir_\(commonDir.id)".hash
+    }
+
+    private func customNewFileMenuItem() -> NSMenuItem {
+        let item = NSMenuItem(title: AppLocalization.localized("Create Blank File"), action: #selector(handleNewFileClick(_:)), keyEquivalent: "")
+        item.tag = hashForCustomNewFile()
+        item.target = self
+        item.image = templateSymbol("doc.badge.plus")
+        return item
     }
 
     // MARK: - Menu Action Handlers
@@ -456,21 +473,24 @@ class FinderSyncExt: FIFinderSync, @unchecked Sendable {
     }
 
     @objc private func handleNewFileClick(_ sender: NSMenuItem) {
-        guard let config = cachedMenuConfig,
-              let newFile = config.newFiles.first(where: { hashForNewFile($0) == sender.tag }) else {
-            logger.warning("NewFile not found for tag: \(sender.tag)")
-            return
+        let itemId: String
+        if sender.tag == hashForCustomNewFile() {
+            itemId = NewFileMenuItem.customFileId
+            logger.debug("Custom New File clicked")
+        } else {
+            guard let config = cachedMenuConfig,
+                  let newFile = config.newFiles.first(where: { hashForNewFile($0) == sender.tag }) else {
+                logger.warning("NewFile not found for tag: \(sender.tag)")
+                return
+            }
+            itemId = newFile.id
+            logger.debug("NewFile clicked: \(newFile.name) (id: \(newFile.id))")
         }
 
-        logger.debug("NewFile clicked: \(newFile.name) (id: \(newFile.id))")
-
-        let selectedItems = FIFinderSyncController.default().selectedItemURLs() ?? []
-        let itemPaths = selectedItems.map { $0.path }
-
         let event = ClickEventPayload(
-            itemId: newFile.id,
+            itemId: itemId,
             itemType: .newFile,
-            target: itemPaths,
+            target: newFileTargetPaths(),
             trigger: getTriggerForMenuKind()
         )
         messager.sendClickEvent(event)
@@ -513,6 +533,24 @@ class FinderSyncExt: FIFinderSync, @unchecked Sendable {
         default:
             return .contextualItems
         }
+    }
+
+    private func newFileTargetPaths() -> [String] {
+        if currentMenuKind == .contextualMenuForContainer,
+           let targetURL = FIFinderSyncController.default().targetedURL() {
+            return [targetURL.path]
+        }
+
+        let selectedItems = FIFinderSyncController.default().selectedItemURLs() ?? []
+        if !selectedItems.isEmpty {
+            return selectedItems.map { $0.path }
+        }
+
+        if let targetURL = FIFinderSyncController.default().targetedURL() {
+            return [targetURL.path]
+        }
+
+        return []
     }
 }
 

--- a/FinderSyncExt/Localizable.xcstrings
+++ b/FinderSyncExt/Localizable.xcstrings
@@ -176,6 +176,12 @@
             "state": "translated",
             "value": "用...打开"
           }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "このアプリケーションで開く"
+          }
         }
       }
     },

--- a/FinderSyncExt/Localizable.xcstrings
+++ b/FinderSyncExt/Localizable.xcstrings
@@ -162,6 +162,29 @@
         }
       }
     },
+    "Create Blank File": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Blank File..."
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "空白文件..."
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "空のファイル..."
+          }
+        }
+      }
+    },
     "Open With": {
       "extractionState": "manual",
       "localizations": {

--- a/RClick/AppState.swift
+++ b/RClick/AppState.swift
@@ -98,6 +98,11 @@ class AppState: ObservableObject {
         }
     }
 
+    @MainActor func moveApps(from source: IndexSet, to destination: Int) {
+        apps.move(fromOffsets: source, toOffset: destination)
+        persistMenuOrder()
+    }
+
     @MainActor
     func updateApp(id: String, itemName: String, arguments: [String], environment: [String: String]) {
         if let index = apps.firstIndex(where: { $0.id == id }) {
@@ -132,6 +137,11 @@ class AppState: ObservableObject {
             logger.info("save error: \(error.localizedDescription)")
         }
     }
+
+    @MainActor func moveNewFiles(from source: IndexSet, to destination: Int) {
+        newFiles.move(fromOffsets: source, toOffset: destination)
+        persistMenuOrder()
+    }
     
     func getActionItem(rid: String) -> RCAction? {
         actions.first(where: { rcAtion in
@@ -143,6 +153,11 @@ class AppState: ObservableObject {
     @MainActor func toggleActionItem() {
         try? save()
         NotificationCenter.default.post(name: .menuConfigShouldUpdate, object: nil)
+    }
+
+    @MainActor func moveActions(from source: IndexSet, to destination: Int) {
+        actions.move(fromOffsets: source, toOffset: destination)
+        persistMenuOrder()
     }
 
     @MainActor func resetActionItems() {
@@ -164,13 +179,39 @@ class AppState: ObservableObject {
     }
 
     @MainActor
+    private func persistMenuOrder() {
+        reindexMenuItems()
+        do {
+            try save()
+            NotificationCenter.default.post(name: .menuConfigShouldUpdate, object: nil)
+        } catch {
+            logger.info("save error: \(error.localizedDescription)")
+        }
+    }
+
+    @MainActor
+    private func reindexMenuItems() {
+        actions = actions.enumerated().map { index, action in
+            var action = action
+            action.idx = index
+            return action
+        }
+        newFiles = newFiles.enumerated().map { index, newFile in
+            var newFile = newFile
+            newFile.idx = index
+            return newFile
+        }
+    }
+
+    @MainActor
     private func save() throws {
         let context = modelContext
+        reindexMenuItems()
 
         // 保存 Apps
         try context.delete(model: AppEntity.self)
-        for app in apps {
-            context.insert(AppEntity(from: app))
+        for (index, app) in apps.enumerated() {
+            context.insert(AppEntity(from: app, sortOrder: index))
         }
 
         // 保存 Actions

--- a/RClick/Localizable.xcstrings
+++ b/RClick/Localizable.xcstrings
@@ -1,39 +1,6 @@
 {
   "sourceLanguage": "en",
   "strings": {
-    "": {
-      "extractionState": "stale",
-      "localizations": {
-        "zh-Hans": {
-          "stringUnit": {
-            "state": "translated",
-            "value": ""
-          }
-        }
-      }
-    },
-    "%@": {},
-    "%@（%@）": {
-      "extractionState": "stale",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "new",
-            "value": "%1$@（%2$@）"
-          }
-        },
-        "zh-Hans": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "%1$@（%2$@）"
-          }
-        }
-      }
-    },
-    "1. 点击右侧「设置…」按钮打开系统设置": {},
-    "2. 点击左下角锁图标并认证": {},
-    "3. 点击「+」→ 前往「应用程序」→ 选择「RClick」": {},
-    "4. 确保 RClick 旁边的开关已打开": {},
     "About": {
       "extractionState": "manual",
       "localizations": {
@@ -621,7 +588,7 @@
         "ja": {
           "stringUnit": {
             "state": "translated",
-            "value": "あとで"
+            "value": "後で"
           }
         }
       }
@@ -765,6 +732,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "用...打开"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "このアプリケーションで開く"
           }
         }
       }
@@ -3789,6 +3762,52 @@
           "stringUnit": {
             "state": "translated",
             "value": "警告"
+          }
+        }
+      }
+    },
+    "Language Change Requires Restart": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Language Change Requires Restart"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "语言切换需要重启"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "言語の変更には再起動が必要です"
+          }
+        }
+      }
+    },
+    "Some interface elements and Finder menus will update after restarting RClick.": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Some interface elements and Finder menus will update after restarting RClick."
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "部分界面元素和 Finder 菜单会在重启 RClick 后更新。"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "一部の画面要素とFinderメニューは、RClickの再起動後に更新されます。"
           }
         }
       }

--- a/RClick/Localizable.xcstrings
+++ b/RClick/Localizable.xcstrings
@@ -656,6 +656,29 @@
         }
       }
     },
+    "Create Blank File": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Blank File..."
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "空白文件..."
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "空のファイル..."
+          }
+        }
+      }
+    },
     "Not Authorized Folder": {
       "extractionState": "stale",
       "localizations": {

--- a/RClick/RClickApp.swift
+++ b/RClick/RClickApp.swift
@@ -5,6 +5,7 @@
 //  Created by 李旭 on 2024/4/4.
 //
 import AppKit
+import ApplicationServices
 import Foundation
 import SwiftUI
 import SwiftData
@@ -393,6 +394,44 @@ class AppDelegate: NSObject, NSApplicationDelegate {
         return filePath
     }
 
+    private func targetDirectoryForNewFile(_ target: [String]) -> String? {
+        guard let rawPath = target.first else { return nil }
+        let path = rawPath.removingPercentEncoding ?? rawPath
+        var isDirectory: ObjCBool = false
+
+        if FileManager.default.fileExists(atPath: path, isDirectory: &isDirectory) {
+            if isDirectory.boolValue {
+                return path
+            }
+            return URL(fileURLWithPath: path).deletingLastPathComponent().path
+        }
+
+        return path
+    }
+
+    private func revealInFinderAndRename(_ fileURL: URL) {
+        NSWorkspace.shared.activateFileViewerSelecting([fileURL])
+
+        DispatchQueue.main.asyncAfter(deadline: .now() + 0.35) { [logger] in
+            let options = ["AXTrustedCheckOptionPrompt": true] as CFDictionary
+            guard AXIsProcessTrustedWithOptions(options) else {
+                logger.warning("Accessibility permission is required to trigger Finder rename for \(fileURL.path)")
+                return
+            }
+
+            NSRunningApplication.runningApplications(withBundleIdentifier: "com.apple.finder").first?.activate()
+
+            DispatchQueue.main.asyncAfter(deadline: .now() + 0.25) {
+                let keyCodeReturn: CGKeyCode = 36
+                let source = CGEventSource(stateID: .hidSystemState)
+                let keyDown = CGEvent(keyboardEventSource: source, virtualKey: keyCodeReturn, keyDown: true)
+                let keyUp = CGEvent(keyboardEventSource: source, virtualKey: keyCodeReturn, keyDown: false)
+                keyDown?.post(tap: .cghidEventTap)
+                keyUp?.post(tap: .cghidEventTap)
+            }
+        }
+    }
+
     func actionHandler(rid: String, target: [String], trigger: String) {
         guard let rcitem = appState.getActionItem(rid: rid) else {
             logger.warning("when createFile, but not have fileType ")
@@ -605,14 +644,32 @@ class AppDelegate: NSObject, NSApplicationDelegate {
     }
 
     func createFile(rid: String, target: [String]) {
-        guard let rcitem = appState.getFileType(rid: rid), let dirPath = target.first else {
+        guard let dirPath = targetDirectoryForNewFile(target) else {
+            logger.warning("when createFile, but not have target directory")
+            return
+        }
+
+        if rid == NewFileMenuItem.customFileId {
+            let filePath = getUniqueFilePath(dir: dirPath, ext: "")
+            let fileURL = URL(fileURLWithPath: filePath)
+            do {
+                try Data().write(to: fileURL)
+                logger.info("created editable file: \(fileURL.path)")
+                revealInFinderAndRename(fileURL)
+            } catch {
+                logger.error("create editable file error: \(error.localizedDescription)")
+            }
+            return
+        }
+
+        guard let rcitem = appState.getFileType(rid: rid) else {
             logger.warning("when createFile, but not have fileType \(rid) ")
             return
         }
 
         let ext = rcitem.ext
         logger.info("create file dir:\(dirPath) -- ext \(ext)")
-        let filePath = getUniqueFilePath(dir: dirPath.removingPercentEncoding ?? dirPath, ext: ext)
+        let filePath = getUniqueFilePath(dir: dirPath, ext: ext)
         let fileURL = URL(fileURLWithPath: filePath)
 
         // 使用完全磁盘访问权限，直接创建文件
@@ -632,6 +689,7 @@ class AppDelegate: NSObject, NSApplicationDelegate {
                     try Data().write(to: fileURL)
                 }
             }
+            revealInFinderAndRename(fileURL)
         } catch let error as NSError {
             switch error.domain {
             case NSCocoaErrorDomain:

--- a/RClick/Settings/ActionSettingsTabView.swift
+++ b/RClick/Settings/ActionSettingsTabView.swift
@@ -21,20 +21,33 @@ struct ActionSettingsTabView: View {
                     .onChange(of: appState.foldActionsMenu) {
                         NotificationCenter.default.post(name: .menuConfigShouldUpdate, object: nil)
                     }
+            }
 
-                ForEach($appState.actions) { $item in
-                    LabeledContent {
-                        Toggle(AppLocalization.localized("Enabled"), isOn: $item.enabled)
-                            .toggleStyle(.switch)
-                            .onChange(of: item.enabled) {
-                                appState.toggleActionItem()
-                                messager.sendRunningNotification()
+            Section {
+                List {
+                    ForEach($appState.actions) { $item in
+                        LabeledContent {
+                            Toggle(AppLocalization.localized("Enabled"), isOn: $item.enabled)
+                                .toggleStyle(.switch)
+                                .onChange(of: item.enabled) {
+                                    appState.toggleActionItem()
+                                    messager.sendRunningNotification()
+                                }
+                                .labelsHidden()
+                        } label: {
+                            HStack(spacing: 8) {
+                                Image(systemName: "line.3.horizontal")
+                                    .foregroundColor(.secondary)
+                                Label(item.displayName, systemImage: item.icon)
                             }
-                            .labelsHidden()
-                    } label: {
-                        Label(item.displayName, systemImage: item.icon)
+                        }
+                    }
+                    .onMove { source, destination in
+                        appState.moveActions(from: source, to: destination)
+                        messager.sendRunningNotification()
                     }
                 }
+                .frame(minHeight: 180)
             } footer: {
                 HStack {
                     Spacer()

--- a/RClick/Settings/AppsSettingsTabView.swift
+++ b/RClick/Settings/AppsSettingsTabView.swift
@@ -39,42 +39,51 @@ struct AppsSettingsTabView: View {
                     }
                 }
 
-                ForEach(appState.apps) { item in
-                    LabeledContent {
-                        HStack(spacing: 8) {
-                            Button {
-                                editingApp = item
-                            } label: {
-                                Image(systemName: "pencil")
-                            }
-                            .buttonStyle(.borderless)
-                            .help(AppLocalization.localized("Edit App"))
+                List {
+                    ForEach(appState.apps) { item in
+                        LabeledContent {
+                            HStack(spacing: 8) {
+                                Button {
+                                    editingApp = item
+                                } label: {
+                                    Image(systemName: "pencil")
+                                }
+                                .buttonStyle(.borderless)
+                                .help(AppLocalization.localized("Edit App"))
 
-                            Button {
-                                deleteApp(item)
-                            } label: {
-                                Image(systemName: "trash")
+                                Button {
+                                    deleteApp(item)
+                                } label: {
+                                    Image(systemName: "trash")
+                                }
+                                .buttonStyle(.borderless)
+                                .help(AppLocalization.localized("Delete App"))
                             }
-                            .buttonStyle(.borderless)
-                            .help(AppLocalization.localized("Delete App"))
-                        }
-                    } label: {
-                        HStack(spacing: 8) {
-                            Image(nsImage: IconCache.shared.icon(for: item.url))
-                                .resizable()
-                                .aspectRatio(contentMode: .fit)
-                                .frame(width: 24, height: 24)
-                            VStack(alignment: .leading, spacing: 2) {
-                                Text(item.name)
-                                if !item.arguments.isEmpty || !item.environment.isEmpty {
-                                    Text(appSummary(item))
-                                        .font(.caption)
-                                        .foregroundColor(.secondary)
+                        } label: {
+                            HStack(spacing: 8) {
+                                Image(systemName: "line.3.horizontal")
+                                    .foregroundColor(.secondary)
+                                Image(nsImage: IconCache.shared.icon(for: item.url))
+                                    .resizable()
+                                    .aspectRatio(contentMode: .fit)
+                                    .frame(width: 24, height: 24)
+                                VStack(alignment: .leading, spacing: 2) {
+                                    Text(item.name)
+                                    if !item.arguments.isEmpty || !item.environment.isEmpty {
+                                        Text(appSummary(item))
+                                            .font(.caption)
+                                            .foregroundColor(.secondary)
+                                    }
                                 }
                             }
                         }
                     }
+                    .onMove { source, destination in
+                        appState.moveApps(from: source, to: destination)
+                        messager.sendRunningNotification()
+                    }
                 }
+                .frame(minHeight: 180)
             }
         }
         .formStyle(.grouped)

--- a/RClick/Settings/GeneralSettingsTabView.swift
+++ b/RClick/Settings/GeneralSettingsTabView.swift
@@ -28,6 +28,7 @@ struct GeneralSettingsTabView: View {
     @State private var showDirImporter = false
     @State private var wrongFold = false
     @State private var showAlert = false
+    @State private var showLanguageRestartAlert = false
 
     let messager = Messager.shared
 
@@ -62,7 +63,11 @@ struct GeneralSettingsTabView: View {
 
                 Picker(selection: Binding(
                     get: { store.selectedLanguage },
-                    set: { store.selectedLanguage = $0 }
+                    set: { newValue in
+                        guard newValue != store.selectedLanguage else { return }
+                        store.selectedLanguage = newValue
+                        showLanguageRestartAlert = true
+                    }
                 )) {
                     Text(appLocalized: "Automatic").tag(AppLanguage.automatic)
                     Text(appLocalized: "Simplified Chinese").tag(AppLanguage.simplifiedChinese)
@@ -75,6 +80,7 @@ struct GeneralSettingsTabView: View {
                 Text(appLocalized: "Main Controls")
             } footer: {
                 Text(appLocalized: "Enable RClick in File Provider to show its actions in Finder context menus")
+                    .fixedSize(horizontal: false, vertical: true)
             }
 
             // MARK: - 第二组：权限
@@ -113,16 +119,23 @@ struct GeneralSettingsTabView: View {
                 VStack(alignment: .leading, spacing: 4) {
                     Text(appLocalized: "File Provider: Select \"RClick\" in the list to enable the Finder context menu")
                         .foregroundColor(.secondary)
+                        .fixedSize(horizontal: false, vertical: true)
                     Text(appLocalized: "Full Disk Access: Required to create and delete files in protected directories")
                         .foregroundColor(.secondary)
+                        .fixedSize(horizontal: false, vertical: true)
                     if fullDiskAccessStatus != .enabled {
                         VStack(alignment: .leading, spacing: 4) {
                             Text(appLocalized: "RClick needs Full Disk Access to work with files in protected directories")
                                 .fontWeight(.medium)
+                                .fixedSize(horizontal: false, vertical: true)
                             Text(appLocalized: "1. Click \"Settings…\" on the right to open System Settings")
+                                .fixedSize(horizontal: false, vertical: true)
                             Text(appLocalized: "2. Click the lock icon and authenticate")
+                                .fixedSize(horizontal: false, vertical: true)
                             Text(appLocalized: "3. Click \"+\" -> open \"Applications\" -> select \"RClick\"")
+                                .fixedSize(horizontal: false, vertical: true)
                             Text(appLocalized: "4. Make sure the switch next to RClick is turned on")
+                                .fixedSize(horizontal: false, vertical: true)
                         }
                         .font(.caption)
                         .foregroundColor(.secondary)
@@ -167,6 +180,7 @@ struct GeneralSettingsTabView: View {
                 Text(appLocalized: "Settings Management")
             } footer: {
                 Text(appLocalized: "Resetting all settings restores the default configuration and cannot be undone")
+                    .fixedSize(horizontal: false, vertical: true)
             }
         }
         .formStyle(.grouped)
@@ -195,6 +209,17 @@ struct GeneralSettingsTabView: View {
             }
         } message: {
             Text(appLocalized: "Folder access permission is required to use this feature.")
+        }
+        .alert(
+            Text(appLocalized: "Language Change Requires Restart"),
+            isPresented: $showLanguageRestartAlert
+        ) {
+            Button(AppLocalization.localized("Restart Now")) {
+                restartApplication()
+            }
+            Button(AppLocalization.localized("Later"), role: .cancel) {}
+        } message: {
+            Text(appLocalized: "Some interface elements and Finder menus will update after restarting RClick.")
         }
     }
 
@@ -233,6 +258,12 @@ struct GeneralSettingsTabView: View {
 
     private func openAccessibilitySettings() {
         PermissionChecker.openAccessibilitySettings()
+    }
+
+    private func restartApplication() {
+        let appURL = Bundle.main.bundleURL
+        try? Process.run(URL(fileURLWithPath: "/usr/bin/open"), arguments: ["-n", appURL.path])
+        NSApp.terminate(nil)
     }
 
     // MARK: - 设置管理

--- a/RClick/Settings/NewFileSettingsTabView.swift
+++ b/RClick/Settings/NewFileSettingsTabView.swift
@@ -47,49 +47,58 @@ struct NewFileSettingsTabView: View {
                     }
                 }
 
-                ForEach($appState.newFiles) { $item in
-                    LabeledContent {
-                        HStack(spacing: 12) {
-                            Button {
-                                editingFile = item
-                            } label: {
-                                Image(systemName: "pencil")
-                            }
-                            .buttonStyle(.borderless)
-                            .help(AppLocalization.localized("Edit File Type"))
-
-                            Toggle(AppLocalization.localized("Enabled"), isOn: $item.enabled)
-                                .toggleStyle(.switch)
-                                .onChange(of: item.enabled) {
-                                    appState.toggleActionItem()
-                                    messager.sendRunningNotification()
+                List {
+                    ForEach($appState.newFiles) { $item in
+                        LabeledContent {
+                            HStack(spacing: 12) {
+                                Button {
+                                    editingFile = item
+                                } label: {
+                                    Image(systemName: "pencil")
                                 }
-                                .labelsHidden()
-                        }
-                    } label: {
-                        HStack(spacing: 8) {
-                            // 图标
-                            if let appUrl = item.openApp {
-                                Image(nsImage: IconCache.shared.icon(for: appUrl))
-                                    .resizable()
-                                    .aspectRatio(contentMode: .fit)
-                                    .frame(width: 24, height: 24)
-                            } else if let sysIcon = FileTypeIconProvider.shared.icon(for: item.ext, fallbackSymbol: item.icon) {
-                                Image(nsImage: sysIcon)
-                                    .resizable()
-                                    .aspectRatio(contentMode: .fit)
-                                    .frame(width: 20, height: 20)
-                            }
+                                .buttonStyle(.borderless)
+                                .help(AppLocalization.localized("Edit File Type"))
 
-                            VStack(alignment: .leading, spacing: 2) {
-                                Text(item.name)
-                                Text(String(format: AppLocalization.localized("Extension: %@"), item.ext))
-                                    .font(.caption)
+                                Toggle(AppLocalization.localized("Enabled"), isOn: $item.enabled)
+                                    .toggleStyle(.switch)
+                                    .onChange(of: item.enabled) {
+                                        appState.toggleActionItem()
+                                        messager.sendRunningNotification()
+                                    }
+                                    .labelsHidden()
+                            }
+                        } label: {
+                            HStack(spacing: 8) {
+                                Image(systemName: "line.3.horizontal")
                                     .foregroundColor(.secondary)
+                                // 图标
+                                if let appUrl = item.openApp {
+                                    Image(nsImage: IconCache.shared.icon(for: appUrl))
+                                        .resizable()
+                                        .aspectRatio(contentMode: .fit)
+                                        .frame(width: 24, height: 24)
+                                } else if let sysIcon = FileTypeIconProvider.shared.icon(for: item.ext, fallbackSymbol: item.icon) {
+                                    Image(nsImage: sysIcon)
+                                        .resizable()
+                                        .aspectRatio(contentMode: .fit)
+                                        .frame(width: 20, height: 20)
+                                }
+
+                                VStack(alignment: .leading, spacing: 2) {
+                                    Text(item.name)
+                                    Text(String(format: AppLocalization.localized("Extension: %@"), item.ext))
+                                        .font(.caption)
+                                        .foregroundColor(.secondary)
+                                }
                             }
                         }
                     }
+                    .onMove { source, destination in
+                        appState.moveNewFiles(from: source, to: destination)
+                        messager.sendRunningNotification()
+                    }
                 }
+                .frame(minHeight: 180)
             }
         }
         .formStyle(.grouped)

--- a/Shared/RCBase.swift
+++ b/Shared/RCBase.swift
@@ -287,6 +287,8 @@ struct ActionMenuItem: Codable {
 
 /// Menu item for creating new files
 struct NewFileMenuItem: Codable {
+    static let customFileId = "__rclick_custom_new_file"
+
     let id: String
     let name: String
     let ext: String


### PR DESCRIPTION
## Summary

This PR includes two updates from my fork:

- Polish language switching behavior so manual language changes show a restart hint instead of implying all UI surfaces can refresh immediately.
- Add draggable ordering in Settings for Actions, Apps, and New File entries, with ordering persisted to SwiftData.
- Add an editable blank-file creation flow under New File, and reveal newly created files in Finder rename mode.

## Details

- Uses real `List.onMove` rows for reorderable settings lists on macOS.
- Keeps the "Collapse actions menu" option in its own settings section so it visually matches the other grouped options.
- Reindexes Actions and New File items before saving so their menu order remains stable.
- Saves Apps with their current index as `sortOrder`, matching the existing SwiftData load order.
- Adds a `Blank File...` menu item for developers who want to create arbitrary files by typing the full name and extension directly.
- Keeps the existing specific file-type entries for users who prefer predefined formats.
- Applies the same reveal-and-rename behavior to both blank files and predefined New File templates.
- Uses Finder selection plus an accessibility-gated Return key event to match Finder's native rename flow as closely as public APIs allow.

## Validation

- Built locally with:

```sh
xcodebuild -allowProvisioningUpdates -project RClick.xcodeproj -scheme RClick -configuration Debug -derivedDataPath work/DerivedData-SignedDebug build
```

- Installed and verified the locally signed app and FinderSync extension on macOS.

## Note

Local bundle identifier, signing team, provisioning, entitlement, and App Group changes were intentionally excluded from this PR.
