### PR TITLE
fix: avoid nested .app in release zip and dmg

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -201,8 +201,6 @@ jobs:
           VERSION=${{ steps.version.outputs.version }}
           DMG_NAME="${APP_NAME}-v${VERSION}.dmg"
 
-          cp -R "$APP_PATH" "./${APP_NAME}.app"
-
           create-dmg \
             --volname "${APP_NAME}" \
             --window-pos 200 120 \
@@ -212,7 +210,7 @@ jobs:
             --hide-extension "${APP_NAME}.app" \
             --app-drop-link 450 200 \
             "$DMG_NAME" \
-            "./${APP_NAME}.app"
+            "$APP_PATH"
 
           codesign --force --sign "$CERT_NAME" "$DMG_NAME"
 
@@ -255,8 +253,7 @@ jobs:
           VERSION=${{ steps.version.outputs.version }}
           ZIP_NAME="${APP_NAME}-v${VERSION}.app.zip"
 
-          cp -R "$APP_PATH" "./${APP_NAME}.app"
-          ditto -c -k --sequesterRsrc --keepParent "./${APP_NAME}.app" "$ZIP_NAME"
+          ditto -c -k --sequesterRsrc "$APP_PATH" "$ZIP_NAME"
 
           SHA256=$(shasum -a 256 "$ZIP_NAME" | awk '{print $1}')
           printf '%s  %s\n' "$SHA256" "$ZIP_NAME" > "${ZIP_NAME}.sha256"


### PR DESCRIPTION
Remove --keepParent from ditto and use APP_PATH directly to avoid creating nested RClick.app/RClick.app structure when extracting.