### PR TITLE
feat(i18n): add Latin American Spanish (es) localization

### DIFF
--- a/FinderSyncExt/FinderSyncExt.swift
+++ b/FinderSyncExt/FinderSyncExt.swift
@@ -168,7 +168,7 @@ class FinderSyncExt: FIFinderSync, @unchecked Sendable {
     }
 
     override var toolbarItemToolTip: String {
-        return "RClick: Click for menu options"
+        return AppLocalization.localized("RClick: Click for menu options")
     }
 
     override var toolbarItemImage: NSImage {

--- a/FinderSyncExt/Localizable.xcstrings
+++ b/FinderSyncExt/Localizable.xcstrings
@@ -10,6 +10,12 @@
             "value" : "1. Click \"Settings…\" on the right to open System Settings"
           }
         },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "1. Haz clic en “Ajustes…” a la derecha para abrir Ajustes del Sistema"
+          }
+        },
         "ja" : {
           "stringUnit" : {
             "state" : "translated",
@@ -31,6 +37,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "2. Click the lock icon and authenticate"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "2. Haz clic en el icono del candado y autentícate"
           }
         },
         "ja" : {
@@ -56,6 +68,12 @@
             "value" : "3. Click \"+\" -> open \"Applications\" -> select \"RClick\""
           }
         },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "3. Haz clic en “+” -> abre “Aplicaciones” -> selecciona “RClick”"
+          }
+        },
         "ja" : {
           "stringUnit" : {
             "state" : "translated",
@@ -77,6 +95,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "4. Make sure the switch next to RClick is turned on"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "4. Asegúrate de que el interruptor junto a RClick esté activado"
           }
         },
         "ja" : {
@@ -102,6 +126,12 @@
             "value" : "About"
           }
         },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Acerca de"
+          }
+        },
         "ja" : {
           "stringUnit" : {
             "state" : "translated",
@@ -123,6 +153,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Accessibility"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Accesibilidad"
           }
         },
         "ja" : {
@@ -148,6 +184,12 @@
             "value" : "Actions"
           }
         },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Acciones"
+          }
+        },
         "ja" : {
           "stringUnit" : {
             "state" : "translated",
@@ -169,6 +211,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Add"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Agregar"
           }
         },
         "ja" : {
@@ -194,6 +242,12 @@
             "value" : "Add App"
           }
         },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Agregar aplicación"
+          }
+        },
         "ja" : {
           "stringUnit" : {
             "state" : "translated",
@@ -215,6 +269,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Add File Type"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Agregar tipo de archivo"
           }
         },
         "ja" : {
@@ -240,6 +300,12 @@
             "value" : "Add Folder"
           }
         },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Agregar carpeta"
+          }
+        },
         "ja" : {
           "stringUnit" : {
             "state" : "translated",
@@ -263,6 +329,12 @@
             "value" : "Added Folders"
           }
         },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Carpetas agregadas"
+          }
+        },
         "ja" : {
           "stringUnit" : {
             "state" : "translated",
@@ -281,6 +353,12 @@
       "extractionState" : "manual",
       "localizations" : {
         "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "AirDrop"
+          }
+        },
+        "es" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "AirDrop"
@@ -309,6 +387,12 @@
             "value" : "Applications"
           }
         },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Aplicaciones"
+          }
+        },
         "ja" : {
           "stringUnit" : {
             "state" : "translated",
@@ -327,6 +411,12 @@
       "extractionState" : "manual",
       "localizations" : {
         "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Apps"
+          }
+        },
+        "es" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Apps"
@@ -355,6 +445,12 @@
             "value" : "Arguments (semicolon separated)"
           }
         },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Argumentos (separados por punto y coma)"
+          }
+        },
         "ja" : {
           "stringUnit" : {
             "state" : "translated",
@@ -376,6 +472,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Arguments: %@"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Argumentos: %@"
           }
         },
         "ja" : {
@@ -401,6 +503,12 @@
             "value" : "Authorized"
           }
         },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Autorizado"
+          }
+        },
         "ja" : {
           "stringUnit" : {
             "state" : "translated",
@@ -422,6 +530,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Automatic"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Automático"
           }
         },
         "ja" : {
@@ -447,6 +561,12 @@
             "value" : "Backup"
           }
         },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Respaldo"
+          }
+        },
         "ja" : {
           "stringUnit" : {
             "state" : "translated",
@@ -468,6 +588,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Cancel"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Cancelar"
           }
         },
         "ja" : {
@@ -493,6 +619,12 @@
             "value" : "Change App"
           }
         },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Cambiar aplicación"
+          }
+        },
         "ja" : {
           "stringUnit" : {
             "state" : "translated",
@@ -514,6 +646,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Change Template"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Cambiar plantilla"
           }
         },
         "ja" : {
@@ -539,6 +677,12 @@
             "value" : "Check for Updates"
           }
         },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Buscar actualizaciones"
+          }
+        },
         "ja" : {
           "stringUnit" : {
             "state" : "translated",
@@ -560,6 +704,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Checking for updates..."
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Buscando actualizaciones..."
           }
         },
         "ja" : {
@@ -585,6 +735,12 @@
             "value" : "Choose Default App"
           }
         },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Elegir aplicación predeterminada"
+          }
+        },
         "ja" : {
           "stringUnit" : {
             "state" : "translated",
@@ -606,6 +762,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Choose Template File"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Elegir archivo de plantilla"
           }
         },
         "ja" : {
@@ -631,6 +793,12 @@
             "value" : "Collapse actions menu"
           }
         },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Contraer el menú de acciones"
+          }
+        },
         "ja" : {
           "stringUnit" : {
             "state" : "translated",
@@ -652,6 +820,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Collapse apps menu"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Contraer el menú de aplicaciones"
           }
         },
         "ja" : {
@@ -677,6 +851,12 @@
             "value" : "Collapse menu"
           }
         },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Contraer el menú"
+          }
+        },
         "ja" : {
           "stringUnit" : {
             "state" : "translated",
@@ -698,6 +878,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Collapse new file menu"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Contraer el menú de nuevo archivo"
           }
         },
         "ja" : {
@@ -723,6 +909,12 @@
             "value" : "Common Folders"
           }
         },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Carpetas frecuentes"
+          }
+        },
         "ja" : {
           "stringUnit" : {
             "state" : "translated",
@@ -744,6 +936,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Common Folders"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Carpetas frecuentes"
           }
         },
         "ja" : {
@@ -769,6 +967,12 @@
             "value" : "Copy Path"
           }
         },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Copiar ruta"
+          }
+        },
         "ja" : {
           "stringUnit" : {
             "state" : "translated",
@@ -790,6 +994,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Default Open App"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Aplicación predeterminada"
           }
         },
         "ja" : {
@@ -815,6 +1025,12 @@
             "value" : "Delete App"
           }
         },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Eliminar aplicación"
+          }
+        },
         "ja" : {
           "stringUnit" : {
             "state" : "translated",
@@ -836,6 +1052,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Delete Direct"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Eliminar directamente"
           }
         },
         "ja" : {
@@ -861,6 +1083,12 @@
             "value" : "Desktop"
           }
         },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Escritorio"
+          }
+        },
         "ja" : {
           "stringUnit" : {
             "state" : "translated",
@@ -882,6 +1110,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Display Name"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Nombre visible"
           }
         },
         "ja" : {
@@ -907,6 +1141,12 @@
             "value" : "Documents"
           }
         },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Documentos"
+          }
+        },
         "ja" : {
           "stringUnit" : {
             "state" : "translated",
@@ -928,6 +1168,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Don't Ask Again"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "No preguntar de nuevo"
           }
         },
         "ja" : {
@@ -953,6 +1199,12 @@
             "value" : "Download and Install"
           }
         },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Descargar e instalar"
+          }
+        },
         "ja" : {
           "stringUnit" : {
             "state" : "translated",
@@ -974,6 +1226,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Download Manually"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Descargar manualmente"
           }
         },
         "ja" : {
@@ -999,6 +1257,12 @@
             "value" : "Downloads"
           }
         },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Descargas"
+          }
+        },
         "ja" : {
           "stringUnit" : {
             "state" : "translated",
@@ -1020,6 +1284,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Edit App"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Editar aplicación"
           }
         },
         "ja" : {
@@ -1045,6 +1315,12 @@
             "value" : "Edit App Properties"
           }
         },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Editar propiedades de la aplicación"
+          }
+        },
         "ja" : {
           "stringUnit" : {
             "state" : "translated",
@@ -1066,6 +1342,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Edit File Type"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Editar tipo de archivo"
           }
         },
         "ja" : {
@@ -1091,6 +1373,12 @@
             "value" : "Enable common folders"
           }
         },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Activar carpetas frecuentes"
+          }
+        },
         "ja" : {
           "stringUnit" : {
             "state" : "translated",
@@ -1112,6 +1400,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Enable Full Disk Access"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Activar Acceso total al disco"
           }
         },
         "ja" : {
@@ -1137,6 +1431,12 @@
             "value" : "Enable RClick"
           }
         },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Activar RClick"
+          }
+        },
         "ja" : {
           "stringUnit" : {
             "state" : "translated",
@@ -1158,6 +1458,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Enable RClick in File Provider to show its actions in Finder context menus"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Activa RClick en Proveedor de archivos para que sus acciones aparezcan en los menús contextuales del Finder"
           }
         },
         "ja" : {
@@ -1183,6 +1489,12 @@
             "value" : "Enabled"
           }
         },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Activado"
+          }
+        },
         "ja" : {
           "stringUnit" : {
             "state" : "translated",
@@ -1204,6 +1516,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "English"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Inglés"
           }
         },
         "ja" : {
@@ -1229,6 +1547,12 @@
             "value" : "Enter an SF Symbol name, for example doc.text or curlybraces"
           }
         },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Escribe el nombre de un SF Symbol, por ejemplo doc.text o curlybraces"
+          }
+        },
         "ja" : {
           "stringUnit" : {
             "state" : "translated",
@@ -1250,6 +1574,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Environment Variables"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Variables de entorno"
           }
         },
         "ja" : {
@@ -1275,6 +1605,12 @@
             "value" : "Environment variables: %lld"
           }
         },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Variables de entorno: %lld"
+          }
+        },
         "ja" : {
           "stringUnit" : {
             "state" : "translated",
@@ -1296,6 +1632,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Export Logs…"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Exportar registros…"
           }
         },
         "ja" : {
@@ -1321,6 +1663,12 @@
             "value" : "Export…"
           }
         },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Exportar…"
+          }
+        },
         "ja" : {
           "stringUnit" : {
             "state" : "translated",
@@ -1342,6 +1690,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Extension: %@"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Extensión: %@"
           }
         },
         "ja" : {
@@ -1367,6 +1721,12 @@
             "value" : "Extraction failed: %@"
           }
         },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Error al descomprimir: %@"
+          }
+        },
         "ja" : {
           "stringUnit" : {
             "state" : "translated",
@@ -1388,6 +1748,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Failed to Check for Updates"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "No se pudieron buscar actualizaciones"
           }
         },
         "ja" : {
@@ -1413,6 +1779,12 @@
             "value" : "File Extension"
           }
         },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Extensión de archivo"
+          }
+        },
         "ja" : {
           "stringUnit" : {
             "state" : "translated",
@@ -1434,6 +1806,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "File Provider: Select \"RClick\" in the list to enable the Finder context menu"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Proveedor de archivos: selecciona “RClick” en la lista para activar el menú contextual del Finder"
           }
         },
         "ja" : {
@@ -1459,6 +1837,12 @@
             "value" : "Finder Extension"
           }
         },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Extensión del Finder"
+          }
+        },
         "ja" : {
           "stringUnit" : {
             "state" : "translated",
@@ -1480,6 +1864,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Folder access permission is required to use this feature."
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Se necesita permiso de acceso a la carpeta para usar esta función."
           }
         },
         "ja" : {
@@ -1505,6 +1895,12 @@
             "value" : "Folders cannot be shared via AirDrop: %@"
           }
         },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Las carpetas no se pueden compartir por AirDrop: %@"
+          }
+        },
         "ja" : {
           "stringUnit" : {
             "state" : "translated",
@@ -1526,6 +1922,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "For example: txt, md, json"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Por ejemplo: txt, md, json"
           }
         },
         "ja" : {
@@ -1551,6 +1953,12 @@
             "value" : "Format: KEY=VALUE, one per line"
           }
         },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Formato: CLAVE=VALOR, uno por línea"
+          }
+        },
         "ja" : {
           "stringUnit" : {
             "state" : "translated",
@@ -1572,6 +1980,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Full Disk Access"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Acceso total al disco"
           }
         },
         "ja" : {
@@ -1597,6 +2011,12 @@
             "value" : "Full Disk Access: Required to create and delete files in protected directories"
           }
         },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Acceso total al disco: se necesita para crear y eliminar archivos en directorios protegidos"
+          }
+        },
         "ja" : {
           "stringUnit" : {
             "state" : "translated",
@@ -1615,6 +2035,12 @@
       "extractionState" : "manual",
       "localizations" : {
         "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "General"
+          }
+        },
+        "es" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "General"
@@ -1643,6 +2069,12 @@
             "value" : "Grant Permission"
           }
         },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Otorgar permiso"
+          }
+        },
         "ja" : {
           "stringUnit" : {
             "state" : "translated",
@@ -1664,6 +2096,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Hide"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Ocultar"
           }
         },
         "ja" : {
@@ -1689,6 +2127,12 @@
             "value" : "Home"
           }
         },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Carpeta de inicio"
+          }
+        },
         "ja" : {
           "stringUnit" : {
             "state" : "translated",
@@ -1710,6 +2154,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Icon"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Icono"
           }
         },
         "ja" : {
@@ -1735,6 +2185,12 @@
             "value" : "Ignore This Version"
           }
         },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Ignorar esta versión"
+          }
+        },
         "ja" : {
           "stringUnit" : {
             "state" : "translated",
@@ -1756,6 +2212,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Import…"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Importar…"
           }
         },
         "ja" : {
@@ -1781,6 +2243,12 @@
             "value" : "Installation failed: %@"
           }
         },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Error al instalar: %@"
+          }
+        },
         "ja" : {
           "stringUnit" : {
             "state" : "translated",
@@ -1802,6 +2270,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Invalid Folder"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Carpeta no válida"
           }
         },
         "ja" : {
@@ -1827,6 +2301,12 @@
             "value" : "Japanese"
           }
         },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Japonés"
+          }
+        },
         "ja" : {
           "stringUnit" : {
             "state" : "translated",
@@ -1848,6 +2328,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Language"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Idioma"
           }
         },
         "ja" : {
@@ -1873,6 +2359,12 @@
             "value" : "Later"
           }
         },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Más tarde"
+          }
+        },
         "ja" : {
           "stringUnit" : {
             "state" : "translated",
@@ -1894,6 +2386,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Launch at login"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Abrir al iniciar sesión"
           }
         },
         "ja" : {
@@ -1919,6 +2417,12 @@
             "value" : "Logs"
           }
         },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Registros"
+          }
+        },
         "ja" : {
           "stringUnit" : {
             "state" : "translated",
@@ -1940,6 +2444,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Main Controls"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Controles principales"
           }
         },
         "ja" : {
@@ -1965,6 +2475,12 @@
             "value" : "Name"
           }
         },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Nombre"
+          }
+        },
         "ja" : {
           "stringUnit" : {
             "state" : "translated",
@@ -1986,6 +2502,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "New File"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Nuevo archivo"
           }
         },
         "ja" : {
@@ -2011,6 +2533,12 @@
             "value" : "New Version Available"
           }
         },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Nueva versión disponible"
+          }
+        },
         "ja" : {
           "stringUnit" : {
             "state" : "translated",
@@ -2032,6 +2560,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "No .app application was found in the ZIP file."
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "No se encontró ninguna aplicación .app en el archivo ZIP."
           }
         },
         "ja" : {
@@ -2057,6 +2591,12 @@
             "value" : "No .app.zip application package was found."
           }
         },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "No se encontró ningún paquete de aplicación .app.zip."
+          }
+        },
         "ja" : {
           "stringUnit" : {
             "state" : "translated",
@@ -2078,6 +2618,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "No update is available."
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "No hay actualizaciones disponibles."
           }
         },
         "ja" : {
@@ -2103,6 +2649,12 @@
             "value" : "Not Authorized"
           }
         },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Sin autorización"
+          }
+        },
         "ja" : {
           "stringUnit" : {
             "state" : "translated",
@@ -2126,6 +2678,12 @@
             "value" : "Notice"
           }
         },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Aviso"
+          }
+        },
         "ja" : {
           "stringUnit" : {
             "state" : "translated",
@@ -2144,6 +2702,12 @@
       "extractionState" : "manual",
       "localizations" : {
         "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "OK"
+          }
+        },
+        "es" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "OK"
@@ -2172,6 +2736,12 @@
             "value" : "Open Settings"
           }
         },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Abrir Ajustes"
+          }
+        },
         "ja" : {
           "stringUnit" : {
             "state" : "translated",
@@ -2195,6 +2765,12 @@
             "value" : "Open With"
           }
         },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Abrir con"
+          }
+        },
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
@@ -2210,6 +2786,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Permissions"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Permisos"
           }
         },
         "ja" : {
@@ -2235,6 +2817,12 @@
             "value" : "Please select the correct Applications folder."
           }
         },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Selecciona la carpeta Aplicaciones correcta."
+          }
+        },
         "ja" : {
           "stringUnit" : {
             "state" : "translated",
@@ -2256,6 +2844,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Preview:"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Vista previa:"
           }
         },
         "ja" : {
@@ -2281,6 +2875,12 @@
             "value" : "Protected system folders cannot be deleted: %@"
           }
         },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "No se pueden eliminar las carpetas protegidas del sistema: %@"
+          }
+        },
         "ja" : {
           "stringUnit" : {
             "state" : "translated",
@@ -2302,6 +2902,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Protected system folders cannot be shared: %@"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "No se pueden compartir las carpetas protegidas del sistema: %@"
           }
         },
         "ja" : {
@@ -2327,6 +2933,12 @@
             "value" : "Quit"
           }
         },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Salir"
+          }
+        },
         "ja" : {
           "stringUnit" : {
             "state" : "translated",
@@ -2348,6 +2960,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "RClick (loading...)"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "RClick (cargando...)"
           }
         },
         "ja" : {
@@ -2373,6 +2991,12 @@
             "value" : "RClick is a right-click menu extension that allows you to add applications for opening folders and includes some common actions."
           }
         },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "RClick es una extensión del menú contextual que te permite agregar aplicaciones para abrir carpetas e incluye algunas acciones frecuentes."
+          }
+        },
         "ja" : {
           "stringUnit" : {
             "state" : "translated",
@@ -2394,6 +3018,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "RClick needs Full Disk Access to create files, delete files, and manage hidden files in protected folders (like Desktop, Documents, and Downloads).\n\nWithout this permission, some operations may fail on protected directories.\n\nTo enable:\n1. Click \"Open Settings\" below\n2. Click the lock icon and authenticate\n3. Click \"+\" and add RClick from your Applications folder\n4. Toggle the switch next to RClick to ON"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "RClick necesita Acceso total al disco para crear archivos, eliminar archivos y administrar archivos ocultos en carpetas protegidas, como Escritorio, Documentos y Descargas.\n\nSin este permiso, algunas operaciones pueden fallar en los directorios protegidos.\n\nPara activarlo:\n1. Haz clic en “Abrir Ajustes” más abajo\n2. Haz clic en el icono del candado y autentícate\n3. Haz clic en “+” y agrega RClick desde tu carpeta Aplicaciones\n4. Activa el interruptor junto a RClick"
           }
         },
         "ja" : {
@@ -2419,6 +3049,12 @@
             "value" : "RClick needs Full Disk Access to work with files in protected directories"
           }
         },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "RClick necesita Acceso total al disco para trabajar con archivos en directorios protegidos"
+          }
+        },
         "ja" : {
           "stringUnit" : {
             "state" : "translated",
@@ -2442,6 +3078,12 @@
             "value" : "RClick needs permission to install the update into your Applications folder."
           }
         },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "RClick necesita permiso para instalar la actualización en tu carpeta Aplicaciones."
+          }
+        },
         "ja" : {
           "stringUnit" : {
             "state" : "translated",
@@ -2456,6 +3098,35 @@
         }
       }
     },
+    "RClick: Click for menu options" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "RClick: Click for menu options"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "RClick: haz clic para ver las opciones del menú"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "RClick: クリックしてメニューオプションを表示"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "RClick：点按以显示菜单选项"
+          }
+        }
+      }
+    },
     "Reset" : {
       "extractionState" : "manual",
       "localizations" : {
@@ -2463,6 +3134,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Reset"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Restablecer"
           }
         },
         "ja" : {
@@ -2488,6 +3165,12 @@
             "value" : "Reset All Settings?"
           }
         },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "¿Restablecer todos los ajustes?"
+          }
+        },
         "ja" : {
           "stringUnit" : {
             "state" : "translated",
@@ -2509,6 +3192,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Reset All Settings…"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Restablecer todos los ajustes…"
           }
         },
         "ja" : {
@@ -2534,6 +3223,12 @@
             "value" : "Resetting all settings restores the default configuration and cannot be undone"
           }
         },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Restablecer todos los ajustes restaura la configuración predeterminada y no se puede deshacer"
+          }
+        },
         "ja" : {
           "stringUnit" : {
             "state" : "translated",
@@ -2555,6 +3250,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Restart Later"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Reiniciar más tarde"
           }
         },
         "ja" : {
@@ -2580,6 +3281,12 @@
             "value" : "Restart Now"
           }
         },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Reiniciar ahora"
+          }
+        },
         "ja" : {
           "stringUnit" : {
             "state" : "translated",
@@ -2601,6 +3308,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Restore Defaults"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Restaurar valores predeterminados"
           }
         },
         "ja" : {
@@ -2626,6 +3339,12 @@
             "value" : "Run Arguments"
           }
         },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Argumentos de ejecución"
+          }
+        },
         "ja" : {
           "stringUnit" : {
             "state" : "translated",
@@ -2647,6 +3366,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Save"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Guardar"
           }
         },
         "ja" : {
@@ -2672,6 +3397,12 @@
             "value" : "Separate multiple arguments with semicolons (;)"
           }
         },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Separa varios argumentos con punto y coma (;)"
+          }
+        },
         "ja" : {
           "stringUnit" : {
             "state" : "translated",
@@ -2693,6 +3424,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Settings"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Ajustes"
           }
         },
         "ja" : {
@@ -2718,6 +3455,12 @@
             "value" : "Settings Management"
           }
         },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Administración de ajustes"
+          }
+        },
         "ja" : {
           "stringUnit" : {
             "state" : "translated",
@@ -2739,6 +3482,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Settings…"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Ajustes…"
           }
         },
         "ja" : {
@@ -2764,6 +3513,12 @@
             "value" : "SF Symbol Name"
           }
         },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Nombre del SF Symbol"
+          }
+        },
         "ja" : {
           "stringUnit" : {
             "state" : "translated",
@@ -2785,6 +3540,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Show icon in menu bar"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Mostrar el icono en la barra de menús"
           }
         },
         "ja" : {
@@ -2810,6 +3571,12 @@
             "value" : "Simplified Chinese"
           }
         },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Chino simplificado"
+          }
+        },
         "ja" : {
           "stringUnit" : {
             "state" : "translated",
@@ -2831,6 +3598,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Template"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Plantilla"
           }
         },
         "ja" : {
@@ -2856,6 +3629,12 @@
             "value" : "The application bundle is invalid or damaged."
           }
         },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "El paquete de la aplicación no es válido o está dañado."
+          }
+        },
         "ja" : {
           "stringUnit" : {
             "state" : "translated",
@@ -2877,6 +3656,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "The application has been updated successfully. Restart the app to finish the update."
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "La aplicación se actualizó correctamente. Reinicia la app para finalizar la actualización."
           }
         },
         "ja" : {
@@ -2902,6 +3687,12 @@
             "value" : "The current folder cannot be deleted. Please select files or subfolders instead."
           }
         },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "No se puede eliminar la carpeta actual. En su lugar, selecciona archivos o subcarpetas."
+          }
+        },
         "ja" : {
           "stringUnit" : {
             "state" : "translated",
@@ -2923,6 +3714,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "The current folder cannot be shared. Please select files or subfolders instead."
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "No se puede compartir la carpeta actual. En su lugar, selecciona archivos o subcarpetas."
           }
         },
         "ja" : {
@@ -2948,6 +3745,12 @@
             "value" : "The current version is already up to date."
           }
         },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "La versión actual ya está actualizada."
+          }
+        },
         "ja" : {
           "stringUnit" : {
             "state" : "translated",
@@ -2969,6 +3772,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "The selected folder is a subfolder of an already selected folder. Please choose a different folder."
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "La carpeta seleccionada es una subcarpeta de otra que ya elegiste. Elige una carpeta diferente."
           }
         },
         "ja" : {
@@ -2994,6 +3803,12 @@
             "value" : "The user cancelled authorization."
           }
         },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "El usuario canceló la autorización."
+          }
+        },
         "ja" : {
           "stringUnit" : {
             "state" : "translated",
@@ -3015,6 +3830,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "This will delete all custom configurations and restore the defaults. This action cannot be undone."
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Se eliminarán todas las configuraciones personalizadas y se restaurarán los valores predeterminados. Esta acción no se puede deshacer."
           }
         },
         "ja" : {
@@ -3040,6 +3861,12 @@
             "value" : "Unauthorized Folder"
           }
         },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Carpeta sin autorización"
+          }
+        },
         "ja" : {
           "stringUnit" : {
             "state" : "translated",
@@ -3061,6 +3888,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Unhide"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Mostrar"
           }
         },
         "ja" : {
@@ -3086,6 +3919,12 @@
             "value" : "Unknown"
           }
         },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Desconocido"
+          }
+        },
         "ja" : {
           "stringUnit" : {
             "state" : "translated",
@@ -3107,6 +3946,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Untitled"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Sin título"
           }
         },
         "ja" : {
@@ -3132,6 +3977,12 @@
             "value" : "Up to Date"
           }
         },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Todo actualizado"
+          }
+        },
         "ja" : {
           "stringUnit" : {
             "state" : "translated",
@@ -3153,6 +4004,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Update Installed"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Actualización instalada"
           }
         },
         "ja" : {
@@ -3178,6 +4035,12 @@
             "value" : "Version %@"
           }
         },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Versión %@"
+          }
+        },
         "ja" : {
           "stringUnit" : {
             "state" : "translated",
@@ -3199,6 +4062,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Version %@ (%@)"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Versión %@ (%@)"
           }
         },
         "ja" : {
@@ -3224,6 +4093,12 @@
             "value" : "Version %@ is ignored"
           }
         },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Se ignoró la versión %@"
+          }
+        },
         "ja" : {
           "stringUnit" : {
             "state" : "translated",
@@ -3245,6 +4120,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Warning"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Advertencia"
           }
         },
         "ja" : {

--- a/RClick.xcodeproj/project.pbxproj
+++ b/RClick.xcodeproj/project.pbxproj
@@ -316,6 +316,7 @@
 				Base,
 				"zh-Hans",
 				ja,
+				es,
 			);
 			mainGroup = 5C8A28D12F83D65900FE687C;
 			minimizedProjectReferenceProxies = 1;

--- a/RClick/Localizable.xcstrings
+++ b/RClick/Localizable.xcstrings
@@ -40,6 +40,12 @@
             "value": "1. Click \"Settings…\" on the right to open System Settings"
           }
         },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "1. Haz clic en “Ajustes…” a la derecha para abrir Ajustes del Sistema"
+          }
+        },
         "ja": {
           "stringUnit": {
             "state": "translated",
@@ -61,6 +67,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "2. Click the lock icon and authenticate"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "2. Haz clic en el icono del candado y autentícate"
           }
         },
         "ja": {
@@ -86,6 +98,12 @@
             "value": "3. Click \"+\" -> open \"Applications\" -> select \"RClick\""
           }
         },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "3. Haz clic en “+” -> abre “Aplicaciones” -> selecciona “RClick”"
+          }
+        },
         "ja": {
           "stringUnit": {
             "state": "translated",
@@ -107,6 +125,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "4. Make sure the switch next to RClick is turned on"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "4. Asegúrate de que el interruptor junto a RClick esté activado"
           }
         },
         "ja": {
@@ -132,6 +156,12 @@
             "value": "About"
           }
         },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Acerca de"
+          }
+        },
         "ja": {
           "stringUnit": {
             "state": "translated",
@@ -153,6 +183,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "Accessibility"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Accesibilidad"
           }
         },
         "ja": {
@@ -178,6 +214,12 @@
             "value": "Actions"
           }
         },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Acciones"
+          }
+        },
         "ja": {
           "stringUnit": {
             "state": "translated",
@@ -192,6 +234,35 @@
         }
       }
     },
+    "Add": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Add"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Agregar"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "追加"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "添加"
+          }
+        }
+      }
+    },
     "Add a Folder…": {
       "extractionState": "manual",
       "localizations": {
@@ -199,6 +270,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "Add a Folder…"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Agregar una carpeta…"
           }
         },
         "ja": {
@@ -224,6 +301,12 @@
             "value": "Add App"
           }
         },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Agregar aplicación"
+          }
+        },
         "ja": {
           "stringUnit": {
             "state": "translated",
@@ -245,6 +328,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "Add File Type"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Agregar tipo de archivo"
           }
         },
         "ja": {
@@ -270,6 +359,12 @@
             "value": "Add Folder"
           }
         },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Agregar carpeta"
+          }
+        },
         "ja": {
           "stringUnit": {
             "state": "translated",
@@ -293,6 +388,12 @@
             "value": "Added Folders"
           }
         },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Carpetas agregadas"
+          }
+        },
         "ja": {
           "stringUnit": {
             "state": "translated",
@@ -311,6 +412,12 @@
       "extractionState": "manual",
       "localizations": {
         "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "AirDrop"
+          }
+        },
+        "es": {
           "stringUnit": {
             "state": "translated",
             "value": "AirDrop"
@@ -339,6 +446,12 @@
             "value": "Applications"
           }
         },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Aplicaciones"
+          }
+        },
         "ja": {
           "stringUnit": {
             "state": "translated",
@@ -357,6 +470,12 @@
       "extractionState": "manual",
       "localizations": {
         "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Apps"
+          }
+        },
+        "es": {
           "stringUnit": {
             "state": "translated",
             "value": "Apps"
@@ -385,6 +504,12 @@
             "value": "Are you sure you want to delete \"%@\" (%@)? This action cannot be undone."
           }
         },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "¿Seguro que quieres eliminar “%@” (%@)? Esta acción no se puede deshacer."
+          }
+        },
         "ja": {
           "stringUnit": {
             "state": "translated",
@@ -406,6 +531,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "Arguments (semicolon separated)"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Argumentos (separados por punto y coma)"
           }
         },
         "ja": {
@@ -431,6 +562,12 @@
             "value": "Arguments: %@"
           }
         },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Argumentos: %@"
+          }
+        },
         "ja": {
           "stringUnit": {
             "state": "translated",
@@ -452,6 +589,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "Authorize folders to let RClick create, delete, and manage files in them."
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Autoriza carpetas para que RClick pueda crear, eliminar y administrar archivos en ellas."
           }
         },
         "ja": {
@@ -477,6 +620,12 @@
             "value": "Authorized"
           }
         },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Autorizado"
+          }
+        },
         "ja": {
           "stringUnit": {
             "state": "translated",
@@ -498,6 +647,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "Backup"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Respaldo"
           }
         },
         "ja": {
@@ -523,6 +678,12 @@
             "value": "Cancel"
           }
         },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Cancelar"
+          }
+        },
         "ja": {
           "stringUnit": {
             "state": "translated",
@@ -544,6 +705,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "Change App"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Cambiar aplicación"
           }
         },
         "ja": {
@@ -569,6 +736,12 @@
             "value": "Change Template"
           }
         },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Cambiar plantilla"
+          }
+        },
         "ja": {
           "stringUnit": {
             "state": "translated",
@@ -590,6 +763,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "Check for Updates"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Buscar actualizaciones"
           }
         },
         "ja": {
@@ -615,6 +794,12 @@
             "value": "Checking for updates..."
           }
         },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Buscando actualizaciones..."
+          }
+        },
         "ja": {
           "stringUnit": {
             "state": "translated",
@@ -636,6 +821,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "Choose a folder for RClick to access."
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Elige una carpeta a la que RClick pueda acceder."
           }
         },
         "ja": {
@@ -661,6 +852,12 @@
             "value": "Choose Default App"
           }
         },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Elegir aplicación predeterminada"
+          }
+        },
         "ja": {
           "stringUnit": {
             "state": "translated",
@@ -682,6 +879,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "Choose Template File"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Elegir archivo de plantilla"
           }
         },
         "ja": {
@@ -707,6 +910,12 @@
             "value": "Collapse actions menu"
           }
         },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Contraer el menú de acciones"
+          }
+        },
         "ja": {
           "stringUnit": {
             "state": "translated",
@@ -728,6 +937,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "Collapse apps menu"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Contraer el menú de aplicaciones"
           }
         },
         "ja": {
@@ -753,6 +968,12 @@
             "value": "Collapse menu"
           }
         },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Contraer el menú"
+          }
+        },
         "ja": {
           "stringUnit": {
             "state": "translated",
@@ -774,6 +995,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "Collapse new file menu"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Contraer el menú de nuevo archivo"
           }
         },
         "ja": {
@@ -799,6 +1026,12 @@
             "value": "Common Folders"
           }
         },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Carpetas frecuentes"
+          }
+        },
         "ja": {
           "stringUnit": {
             "state": "translated",
@@ -822,6 +1055,12 @@
             "value": "Copy Path"
           }
         },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Copiar ruta"
+          }
+        },
         "ja": {
           "stringUnit": {
             "state": "translated",
@@ -836,6 +1075,35 @@
         }
       }
     },
+    "Default Open App": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Default Open App"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Aplicación predeterminada"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "既定で開くアプリ"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "默认打开应用"
+          }
+        }
+      }
+    },
     "Delete": {
       "extractionState": "manual",
       "localizations": {
@@ -843,6 +1111,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "Delete"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Eliminar"
           }
         },
         "ja": {
@@ -868,6 +1142,12 @@
             "value": "Delete App"
           }
         },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Eliminar aplicación"
+          }
+        },
         "ja": {
           "stringUnit": {
             "state": "translated",
@@ -889,6 +1169,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "Delete Direct"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Eliminar directamente"
           }
         },
         "ja": {
@@ -914,6 +1200,12 @@
             "value": "Delete File Type"
           }
         },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Eliminar tipo de archivo"
+          }
+        },
         "ja": {
           "stringUnit": {
             "state": "translated",
@@ -937,6 +1229,12 @@
             "value": "Desktop"
           }
         },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Escritorio"
+          }
+        },
         "ja": {
           "stringUnit": {
             "state": "translated",
@@ -951,6 +1249,35 @@
         }
       }
     },
+    "Display Name": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Display Name"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Nombre visible"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "表示名"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "显示名称"
+          }
+        }
+      }
+    },
     "Documents": {
       "extractionState": "manual",
       "localizations": {
@@ -958,6 +1285,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "Documents"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Documentos"
           }
         },
         "ja": {
@@ -983,6 +1316,12 @@
             "value": "Don't Ask Again"
           }
         },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "No preguntar de nuevo"
+          }
+        },
         "ja": {
           "stringUnit": {
             "state": "translated",
@@ -1004,6 +1343,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "Done"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Listo"
           }
         },
         "ja": {
@@ -1029,6 +1374,12 @@
             "value": "Download and Install"
           }
         },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Descargar e instalar"
+          }
+        },
         "ja": {
           "stringUnit": {
             "state": "translated",
@@ -1043,6 +1394,35 @@
         }
       }
     },
+    "Download failed": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Download failed"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "La descarga falló"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "ダウンロードに失敗しました"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "下载失败"
+          }
+        }
+      }
+    },
     "Download Manually": {
       "extractionState": "manual",
       "localizations": {
@@ -1050,6 +1430,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "Download Manually"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Descargar manualmente"
           }
         },
         "ja": {
@@ -1075,6 +1461,12 @@
             "value": "Downloads"
           }
         },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Descargas"
+          }
+        },
         "ja": {
           "stringUnit": {
             "state": "translated",
@@ -1098,6 +1490,12 @@
             "value": "Edit App"
           }
         },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Editar aplicación"
+          }
+        },
         "ja": {
           "stringUnit": {
             "state": "translated",
@@ -1112,6 +1510,35 @@
         }
       }
     },
+    "Edit App Properties": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Edit App Properties"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Editar propiedades de la aplicación"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "アプリ設定を編集"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "编辑应用属性"
+          }
+        }
+      }
+    },
     "Edit File Type": {
       "extractionState": "manual",
       "localizations": {
@@ -1119,6 +1546,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "Edit File Type"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Editar tipo de archivo"
           }
         },
         "ja": {
@@ -1144,6 +1577,12 @@
             "value": "Enable common folders"
           }
         },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Activar carpetas frecuentes"
+          }
+        },
         "ja": {
           "stringUnit": {
             "state": "translated",
@@ -1165,6 +1604,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "Enable Full Disk Access"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Activar Acceso total al disco"
           }
         },
         "ja": {
@@ -1190,6 +1635,12 @@
             "value": "Enable RClick"
           }
         },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Activar RClick"
+          }
+        },
         "ja": {
           "stringUnit": {
             "state": "translated",
@@ -1211,6 +1662,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "Enable RClick in File Provider to show its actions in Finder context menus"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Activa RClick en Proveedor de archivos para que sus acciones aparezcan en los menús contextuales del Finder"
           }
         },
         "ja": {
@@ -1236,6 +1693,12 @@
             "value": "Enabled"
           }
         },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Activado"
+          }
+        },
         "ja": {
           "stringUnit": {
             "state": "translated",
@@ -1257,6 +1720,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "Enter an SF Symbol name, for example doc.text or curlybraces"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Escribe el nombre de un SF Symbol, por ejemplo doc.text o curlybraces"
           }
         },
         "ja": {
@@ -1282,6 +1751,12 @@
             "value": "Environment Variables"
           }
         },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Variables de entorno"
+          }
+        },
         "ja": {
           "stringUnit": {
             "state": "translated",
@@ -1303,6 +1778,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "Environment variables: %lld"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Variables de entorno: %lld"
           }
         },
         "ja": {
@@ -1328,6 +1809,12 @@
             "value": "Export Logs…"
           }
         },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Exportar registros…"
+          }
+        },
         "ja": {
           "stringUnit": {
             "state": "translated",
@@ -1349,6 +1836,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "Export…"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Exportar…"
           }
         },
         "ja": {
@@ -1374,6 +1867,12 @@
             "value": "Extension: %@"
           }
         },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Extensión: %@"
+          }
+        },
         "ja": {
           "stringUnit": {
             "state": "translated",
@@ -1395,6 +1894,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "Extraction failed: %@"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Error al descomprimir: %@"
           }
         },
         "ja": {
@@ -1420,6 +1925,12 @@
             "value": "Failed to Check for Updates"
           }
         },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "No se pudieron buscar actualizaciones"
+          }
+        },
         "ja": {
           "stringUnit": {
             "state": "translated",
@@ -1441,6 +1952,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "File Extension"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Extensión de archivo"
           }
         },
         "ja": {
@@ -1466,6 +1983,12 @@
             "value": "File Provider: Select \"RClick\" in the list to enable the Finder context menu"
           }
         },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Proveedor de archivos: selecciona “RClick” en la lista para activar el menú contextual del Finder"
+          }
+        },
         "ja": {
           "stringUnit": {
             "state": "translated",
@@ -1487,6 +2010,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "Finder Extension"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Extensión del Finder"
           }
         },
         "ja": {
@@ -1512,6 +2041,12 @@
             "value": "Folder access permission is required to use this feature."
           }
         },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Se necesita permiso de acceso a la carpeta para usar esta función."
+          }
+        },
         "ja": {
           "stringUnit": {
             "state": "translated",
@@ -1533,6 +2068,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "Folder Permissions"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Permisos de carpetas"
           }
         },
         "ja": {
@@ -1558,6 +2099,12 @@
             "value": "Folders cannot be shared via AirDrop: %@"
           }
         },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Las carpetas no se pueden compartir por AirDrop: %@"
+          }
+        },
         "ja": {
           "stringUnit": {
             "state": "translated",
@@ -1579,6 +2126,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "For example: txt, md, json"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Por ejemplo: txt, md, json"
           }
         },
         "ja": {
@@ -1604,6 +2157,12 @@
             "value": "Format: KEY=VALUE, one per line"
           }
         },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Formato: CLAVE=VALOR, uno por línea"
+          }
+        },
         "ja": {
           "stringUnit": {
             "state": "translated",
@@ -1625,6 +2184,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "Full Disk Access"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Acceso total al disco"
           }
         },
         "ja": {
@@ -1650,6 +2215,12 @@
             "value": "Full Disk Access: Required to create and delete files in protected directories"
           }
         },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Acceso total al disco: se necesita para crear y eliminar archivos en directorios protegidos"
+          }
+        },
         "ja": {
           "stringUnit": {
             "state": "translated",
@@ -1673,6 +2244,12 @@
             "value": "General"
           }
         },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "General"
+          }
+        },
         "ja": {
           "stringUnit": {
             "state": "translated",
@@ -1687,7 +2264,16 @@
         }
       }
     },
-    "github.com/wflixu/RClick": {},
+    "github.com/wflixu/RClick": {
+      "localizations": {
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "github.com/wflixu/RClick"
+          }
+        }
+      }
+    },
     "Grant Access": {
       "extractionState": "manual",
       "localizations": {
@@ -1695,6 +2281,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "Grant Access"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Permitir acceso"
           }
         },
         "ja": {
@@ -1720,6 +2312,12 @@
             "value": "Grant Permission"
           }
         },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Otorgar permiso"
+          }
+        },
         "ja": {
           "stringUnit": {
             "state": "translated",
@@ -1741,6 +2339,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "Grant RClick access to this folder to perform file operations."
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Otorga a RClick acceso a esta carpeta para realizar operaciones con archivos."
           }
         },
         "ja": {
@@ -1766,6 +2370,12 @@
             "value": "Hide"
           }
         },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Ocultar"
+          }
+        },
         "ja": {
           "stringUnit": {
             "state": "translated",
@@ -1787,6 +2397,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "Home"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Carpeta de inicio"
           }
         },
         "ja": {
@@ -1812,6 +2428,12 @@
             "value": "Icon"
           }
         },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Icono"
+          }
+        },
         "ja": {
           "stringUnit": {
             "state": "translated",
@@ -1833,6 +2455,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "Ignore This Version"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Ignorar esta versión"
           }
         },
         "ja": {
@@ -1858,6 +2486,12 @@
             "value": "Import…"
           }
         },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Importar…"
+          }
+        },
         "ja": {
           "stringUnit": {
             "state": "translated",
@@ -1879,6 +2513,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "Installation failed: %@"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Error al instalar: %@"
           }
         },
         "ja": {
@@ -1904,6 +2544,12 @@
             "value": "Invalid Folder"
           }
         },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Carpeta no válida"
+          }
+        },
         "ja": {
           "stringUnit": {
             "state": "translated",
@@ -1925,6 +2571,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "Launch at login"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Abrir al iniciar sesión"
           }
         },
         "ja": {
@@ -1950,6 +2602,12 @@
             "value": "Logs"
           }
         },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Registros"
+          }
+        },
         "ja": {
           "stringUnit": {
             "state": "translated",
@@ -1971,6 +2629,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "Main Controls"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Controles principales"
           }
         },
         "ja": {
@@ -1996,6 +2660,12 @@
             "value": "Manage…"
           }
         },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Administrar…"
+          }
+        },
         "ja": {
           "stringUnit": {
             "state": "translated",
@@ -2017,6 +2687,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "Name"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Nombre"
           }
         },
         "ja": {
@@ -2042,6 +2718,12 @@
             "value": "New File"
           }
         },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Nuevo archivo"
+          }
+        },
         "ja": {
           "stringUnit": {
             "state": "translated",
@@ -2063,6 +2745,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "New Version Available"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Nueva versión disponible"
           }
         },
         "ja": {
@@ -2088,6 +2776,12 @@
             "value": "No .app application was found in the ZIP file."
           }
         },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "No se encontró ninguna aplicación .app en el archivo ZIP."
+          }
+        },
         "ja": {
           "stringUnit": {
             "state": "translated",
@@ -2109,6 +2803,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "No .app.zip application package was found."
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "No se encontró ningún paquete de aplicación .app.zip."
           }
         },
         "ja": {
@@ -2134,6 +2834,12 @@
             "value": "No folders authorized"
           }
         },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "No hay carpetas autorizadas"
+          }
+        },
         "ja": {
           "stringUnit": {
             "state": "translated",
@@ -2155,6 +2861,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "No update is available."
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "No hay actualizaciones disponibles."
           }
         },
         "ja": {
@@ -2180,6 +2892,12 @@
             "value": "Not Authorized"
           }
         },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Sin autorización"
+          }
+        },
         "ja": {
           "stringUnit": {
             "state": "translated",
@@ -2203,6 +2921,12 @@
             "value": "Notice"
           }
         },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Aviso"
+          }
+        },
         "ja": {
           "stringUnit": {
             "state": "translated",
@@ -2217,6 +2941,35 @@
         }
       }
     },
+    "OK": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "OK"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "OK"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "OK"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "确定"
+          }
+        }
+      }
+    },
     "Open Settings": {
       "extractionState": "manual",
       "localizations": {
@@ -2224,6 +2977,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "Open Settings"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Abrir Ajustes"
           }
         },
         "ja": {
@@ -2249,6 +3008,12 @@
             "value": "Open With"
           }
         },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Abrir con"
+          }
+        },
         "zh-Hans": {
           "stringUnit": {
             "state": "translated",
@@ -2266,6 +3031,12 @@
             "value": "Open With %@"
           }
         },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Abrir con %@"
+          }
+        },
         "zh-Hans": {
           "stringUnit": {
             "state": "translated",
@@ -2281,6 +3052,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "Permissions"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Permisos"
           }
         },
         "ja": {
@@ -2306,6 +3083,12 @@
             "value": "Please select the correct Applications folder."
           }
         },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Selecciona la carpeta Aplicaciones correcta."
+          }
+        },
         "ja": {
           "stringUnit": {
             "state": "translated",
@@ -2329,6 +3112,12 @@
             "value": "PPTX"
           }
         },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "PPTX"
+          }
+        },
         "zh-Hans": {
           "stringUnit": {
             "state": "translated",
@@ -2344,6 +3133,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "Preview:"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Vista previa:"
           }
         },
         "ja": {
@@ -2369,6 +3164,12 @@
             "value": "Protected system folders cannot be deleted: %@"
           }
         },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "No se pueden eliminar las carpetas protegidas del sistema: %@"
+          }
+        },
         "ja": {
           "stringUnit": {
             "state": "translated",
@@ -2390,6 +3191,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "Protected system folders cannot be shared: %@"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "No se pueden compartir las carpetas protegidas del sistema: %@"
           }
         },
         "ja": {
@@ -2415,6 +3222,12 @@
             "value": "Quit"
           }
         },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Salir"
+          }
+        },
         "ja": {
           "stringUnit": {
             "state": "translated",
@@ -2437,6 +3250,12 @@
             "value": "RClick"
           }
         },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "RClick"
+          }
+        },
         "zh-Hans": {
           "stringUnit": {
             "state": "translated",
@@ -2452,6 +3271,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "RClick (loading...)"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "RClick (cargando...)"
           }
         },
         "ja": {
@@ -2477,6 +3302,12 @@
             "value": "RClick is a right-click menu extension that allows you to add applications for opening folders and includes some common actions!"
           }
         },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "RClick es una extensión del menú contextual que te permite agregar aplicaciones para abrir carpetas e incluye algunas acciones frecuentes."
+          }
+        },
         "zh-Hans": {
           "stringUnit": {
             "state": "translated",
@@ -2492,6 +3323,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "RClick is a right-click menu extension that allows you to add applications for opening folders and includes some common actions."
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "RClick es una extensión del menú contextual que te permite agregar aplicaciones para abrir carpetas e incluye algunas acciones frecuentes."
           }
         },
         "ja": {
@@ -2517,6 +3354,12 @@
             "value": "RClick needs Full Disk Access to create files, delete files, and manage hidden files in protected folders (like Desktop, Documents, and Downloads).\n\nWithout this permission, some operations may fail on protected directories.\n\nTo enable:\n1. Click \"Open Settings\" below\n2. Click the lock icon and authenticate\n3. Click \"+\" and add RClick from your Applications folder\n4. Toggle the switch next to RClick to ON"
           }
         },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "RClick necesita Acceso total al disco para crear archivos, eliminar archivos y administrar archivos ocultos en carpetas protegidas, como Escritorio, Documentos y Descargas.\n\nSin este permiso, algunas operaciones pueden fallar en los directorios protegidos.\n\nPara activarlo:\n1. Haz clic en “Abrir Ajustes” más abajo\n2. Haz clic en el icono del candado y autentícate\n3. Haz clic en “+” y agrega RClick desde tu carpeta Aplicaciones\n4. Activa el interruptor junto a RClick"
+          }
+        },
         "ja": {
           "stringUnit": {
             "state": "translated",
@@ -2538,6 +3381,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "RClick needs Full Disk Access to work with files in protected directories"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "RClick necesita Acceso total al disco para trabajar con archivos en directorios protegidos"
           }
         },
         "ja": {
@@ -2563,6 +3412,12 @@
             "value": "RClick needs permission to install the update into your Applications folder."
           }
         },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "RClick necesita permiso para instalar la actualización en tu carpeta Aplicaciones."
+          }
+        },
         "ja": {
           "stringUnit": {
             "state": "translated",
@@ -2584,6 +3439,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "Remove folder permission"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Quitar el permiso de la carpeta"
           }
         },
         "ja": {
@@ -2609,6 +3470,12 @@
             "value": "Reset"
           }
         },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Restablecer"
+          }
+        },
         "ja": {
           "stringUnit": {
             "state": "translated",
@@ -2630,6 +3497,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "Reset All Settings?"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "¿Restablecer todos los ajustes?"
           }
         },
         "ja": {
@@ -2655,6 +3528,12 @@
             "value": "Reset All Settings…"
           }
         },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Restablecer todos los ajustes…"
+          }
+        },
         "ja": {
           "stringUnit": {
             "state": "translated",
@@ -2676,6 +3555,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "Resetting all settings restores the default configuration and cannot be undone"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Restablecer todos los ajustes restaura la configuración predeterminada y no se puede deshacer"
           }
         },
         "ja": {
@@ -2701,6 +3586,12 @@
             "value": "Restart Later"
           }
         },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Reiniciar más tarde"
+          }
+        },
         "ja": {
           "stringUnit": {
             "state": "translated",
@@ -2722,6 +3613,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "Restart Now"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Reiniciar ahora"
           }
         },
         "ja": {
@@ -2747,6 +3644,12 @@
             "value": "Restore Defaults"
           }
         },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Restaurar valores predeterminados"
+          }
+        },
         "ja": {
           "stringUnit": {
             "state": "translated",
@@ -2770,6 +3673,12 @@
             "value": "Run Arguments"
           }
         },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Argumentos de ejecución"
+          }
+        },
         "ja": {
           "stringUnit": {
             "state": "translated",
@@ -2784,6 +3693,35 @@
         }
       }
     },
+    "Save": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Save"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Guardar"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "保存"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "保存"
+          }
+        }
+      }
+    },
     "Separate multiple arguments with semicolons (;)": {
       "extractionState": "manual",
       "localizations": {
@@ -2791,6 +3729,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "Separate multiple arguments with semicolons (;)"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Separa varios argumentos con punto y coma (;)"
           }
         },
         "ja": {
@@ -2816,6 +3760,12 @@
             "value": "Settings"
           }
         },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Ajustes"
+          }
+        },
         "ja": {
           "stringUnit": {
             "state": "translated",
@@ -2837,6 +3787,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "Settings Management"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Administración de ajustes"
           }
         },
         "ja": {
@@ -2862,6 +3818,12 @@
             "value": "Settings…"
           }
         },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Ajustes…"
+          }
+        },
         "ja": {
           "stringUnit": {
             "state": "translated",
@@ -2883,6 +3845,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "SF Symbol Name"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Nombre del SF Symbol"
           }
         },
         "ja": {
@@ -2908,6 +3876,12 @@
             "value": "Show icon in menu bar"
           }
         },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Mostrar el icono en la barra de menús"
+          }
+        },
         "ja": {
           "stringUnit": {
             "state": "translated",
@@ -2929,6 +3903,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "Template"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Plantilla"
           }
         },
         "ja": {
@@ -2954,6 +3934,12 @@
             "value": "The application bundle is invalid or damaged."
           }
         },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "El paquete de la aplicación no es válido o está dañado."
+          }
+        },
         "ja": {
           "stringUnit": {
             "state": "translated",
@@ -2975,6 +3961,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "The application has been updated successfully. Restart the app to finish the update."
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "La aplicación se actualizó correctamente. Reinicia la app para finalizar la actualización."
           }
         },
         "ja": {
@@ -3000,6 +3992,12 @@
             "value": "The current folder cannot be deleted. Please select files or subfolders instead."
           }
         },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "No se puede eliminar la carpeta actual. En su lugar, selecciona archivos o subcarpetas."
+          }
+        },
         "ja": {
           "stringUnit": {
             "state": "translated",
@@ -3021,6 +4019,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "The current folder cannot be shared. Please select files or subfolders instead."
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "No se puede compartir la carpeta actual. En su lugar, selecciona archivos o subcarpetas."
           }
         },
         "ja": {
@@ -3046,6 +4050,12 @@
             "value": "The current version is already up to date."
           }
         },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "La versión actual ya está actualizada."
+          }
+        },
         "ja": {
           "stringUnit": {
             "state": "translated",
@@ -3067,6 +4077,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "The selected folder is a subfolder of an already selected folder. Please choose a different folder."
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "La carpeta seleccionada es una subcarpeta de otra que ya elegiste. Elige una carpeta diferente."
           }
         },
         "ja": {
@@ -3092,6 +4108,12 @@
             "value": "The user cancelled authorization."
           }
         },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "El usuario canceló la autorización."
+          }
+        },
         "ja": {
           "stringUnit": {
             "state": "translated",
@@ -3113,6 +4135,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "This will delete all custom configurations and restore the defaults. This action cannot be undone."
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Se eliminarán todas las configuraciones personalizadas y se restaurarán los valores predeterminados. Esta acción no se puede deshacer."
           }
         },
         "ja": {
@@ -3138,6 +4166,12 @@
             "value": "Unauthorized Folder"
           }
         },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Carpeta sin autorización"
+          }
+        },
         "ja": {
           "stringUnit": {
             "state": "translated",
@@ -3159,6 +4193,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "Unhide"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Mostrar"
           }
         },
         "ja": {
@@ -3184,6 +4224,12 @@
             "value": "Unknown"
           }
         },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Desconocido"
+          }
+        },
         "ja": {
           "stringUnit": {
             "state": "translated",
@@ -3198,6 +4244,35 @@
         }
       }
     },
+    "Unknown error": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Unknown error"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Error desconocido"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "不明なエラー"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "未知错误"
+          }
+        }
+      }
+    },
     "Untitled": {
       "extractionState": "manual",
       "localizations": {
@@ -3205,6 +4280,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "Untitled"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Sin título"
           }
         },
         "ja": {
@@ -3230,6 +4311,12 @@
             "value": "Up to Date"
           }
         },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Todo actualizado"
+          }
+        },
         "ja": {
           "stringUnit": {
             "state": "translated",
@@ -3251,6 +4338,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "Update Installed"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Actualización instalada"
           }
         },
         "ja": {
@@ -3276,6 +4369,12 @@
             "value": "Version %@"
           }
         },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Versión %@"
+          }
+        },
         "ja": {
           "stringUnit": {
             "state": "translated",
@@ -3297,6 +4396,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "Version %@ (%@)"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Versión %@ (%@)"
           }
         },
         "ja": {
@@ -3322,6 +4427,12 @@
             "value": "Version %@ is ignored"
           }
         },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Se ignoró la versión %@"
+          }
+        },
         "ja": {
           "stringUnit": {
             "state": "translated",
@@ -3345,6 +4456,12 @@
             "value": "Want to add a feature? Give feedback here."
           }
         },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "¿Quieres proponer una función? Envía tus comentarios aquí."
+          }
+        },
         "zh-Hans": {
           "stringUnit": {
             "state": "translated",
@@ -3360,6 +4477,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "Warning"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Advertencia"
           }
         },
         "ja": {

--- a/RClick/Model/ActionEntity.swift
+++ b/RClick/Model/ActionEntity.swift
@@ -47,10 +47,10 @@ final class ActionEntity {
     // 预定义动作的工厂方法（默认只开启前两个）
     static func createDefaultActions() -> [ActionEntity] {
         return [
-            ActionEntity(id: "copy-path", name: "复制路径", icon: "doc.on.doc", isEnabled: true, sortOrder: 0),
-            ActionEntity(id: "delete-direct", name: "直接删除", icon: "trash", isEnabled: true, sortOrder: 1),
-            ActionEntity(id: "hide", name: "隐藏", icon: "eye.slash", isEnabled: false, sortOrder: 2),
-            ActionEntity(id: "unhide", name: "显示", icon: "eye", isEnabled: false, sortOrder: 3),
+            ActionEntity(id: "copy-path", name: "Copy Path", icon: "doc.on.doc", isEnabled: true, sortOrder: 0),
+            ActionEntity(id: "delete-direct", name: "Delete Direct", icon: "trash", isEnabled: true, sortOrder: 1),
+            ActionEntity(id: "hide", name: "Hide", icon: "eye.slash", isEnabled: false, sortOrder: 2),
+            ActionEntity(id: "unhide", name: "Unhide", icon: "eye", isEnabled: false, sortOrder: 3),
             ActionEntity(id: "airdrop", name: "AirDrop", icon: "paperplane", isEnabled: false, sortOrder: 4),
         ]
     }

--- a/RClick/Model/CommonDirEntity.swift
+++ b/RClick/Model/CommonDirEntity.swift
@@ -65,11 +65,11 @@ final class CommonDirEntity {
         let documents = homeDir.appendingPathComponent("Documents")
         let downloads = homeDir.appendingPathComponent("Downloads")
 
-        dirs.append(CommonDirEntity(id: "desktop", name: "桌面", path: desktop, icon: iconForDirectory(url: desktop), sortOrder: 0))
-        dirs.append(CommonDirEntity(id: "documents", name: "文档", path: documents, icon: iconForDirectory(url: documents), sortOrder: 1))
-        dirs.append(CommonDirEntity(id: "downloads", name: "下载", path: downloads, icon: iconForDirectory(url: downloads), sortOrder: 2))
-        dirs.append(CommonDirEntity(id: "applications", name: "应用程序", path: URL(fileURLWithPath: "/Applications"), icon: iconForDirectory(url: URL(fileURLWithPath: "/Applications")), sortOrder: 3))
-        dirs.append(CommonDirEntity(id: "home", name: "用户主目录", path: homeDir, icon: iconForDirectory(url: homeDir), sortOrder: 4))
+        dirs.append(CommonDirEntity(id: "desktop", name: "Desktop", path: desktop, icon: iconForDirectory(url: desktop), sortOrder: 0))
+        dirs.append(CommonDirEntity(id: "documents", name: "Documents", path: documents, icon: iconForDirectory(url: documents), sortOrder: 1))
+        dirs.append(CommonDirEntity(id: "downloads", name: "Downloads", path: downloads, icon: iconForDirectory(url: downloads), sortOrder: 2))
+        dirs.append(CommonDirEntity(id: "applications", name: "Applications", path: URL(fileURLWithPath: "/Applications"), icon: iconForDirectory(url: URL(fileURLWithPath: "/Applications")), sortOrder: 3))
+        dirs.append(CommonDirEntity(id: "home", name: "Home", path: homeDir, icon: iconForDirectory(url: homeDir), sortOrder: 4))
 
         return dirs
     }

--- a/RClick/Shared/Updater.swift
+++ b/RClick/Shared/Updater.swift
@@ -273,6 +273,8 @@ class UpdateManager: ObservableObject {
         var request = URLRequest(url: URL(string: asset.browserDownloadUrl)!)
         request.setValue("application/octet-stream", forHTTPHeaderField: "Accept")
         
+        let downloadFailedMessage = AppLocalization.localized("Download failed")
+        
         // 使用 AsyncThrowingStream 来包装下载进度和结果
         return try await withCheckedThrowingContinuation { continuation in
             // Stream bytes and write to destination file
@@ -290,7 +292,7 @@ class UpdateManager: ObservableObject {
                       let httpResponse = response as? HTTPURLResponse,
                       httpResponse.statusCode == 200
                 else {
-                    continuation.resume(throwing: DownloadError.downloadFailed("下载失败"))
+                    continuation.resume(throwing: DownloadError.downloadFailed(downloadFailedMessage))
                     print("downn error")
                     return
                 }
@@ -337,7 +339,7 @@ class UpdateManager: ObservableObject {
         
         guard process.terminationStatus == 0 else {
             let errorData = errorPipe.fileHandleForReading.readDataToEndOfFile()
-            let errorString = String(data: errorData, encoding: .utf8) ?? "未知错误"
+            let errorString = String(data: errorData, encoding: .utf8) ?? AppLocalization.localized("Unknown error")
             throw InstallationError.zipExtractionFailed(String(format: AppLocalization.localized("Extraction failed: %@"), errorString))
         }
         

--- a/scripts/check-localization.py
+++ b/scripts/check-localization.py
@@ -1,0 +1,130 @@
+#!/usr/bin/env python3
+"""Localization sanity checks for RClick's String Catalogs.
+
+Verifies, for every `Localizable.xcstrings` passed on the command line (or, by
+default, both catalogs of the project):
+
+1. The catalog is valid JSON with the expected top-level shape.
+2. Every key carries a translation for each language in --languages
+   (default: es). Keys whose source string holds no letters at all — bare
+   format specifiers such as "%@" or "%lld" — have nothing to translate and
+   are reported as skipped instead of missing.
+3. Every translation uses exactly the same format specifiers, in the same
+   order, as the source string (the `en` value, or the key itself when the
+   catalog has no explicit `en` entry).
+
+Exit code is 0 when everything passes, 1 otherwise.
+
+Usage:
+    python3 scripts/check-localization.py
+    python3 scripts/check-localization.py --languages es ja zh-Hans
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import re
+import sys
+from pathlib import Path
+
+DEFAULT_CATALOGS = (
+    "RClick/Localizable.xcstrings",
+    "FinderSyncExt/Localizable.xcstrings",
+)
+
+# %@  %1$@  %lld  %2$lld  %d  %f  %%  ...
+SPECIFIER = re.compile(r"%(?:(\d+)\$)?(?:%|@|l{0,2}[dioux]|[eEfgGcs])")
+
+
+def specifiers(text: str) -> list[str]:
+    """Return the format specifiers of `text`, in order of appearance."""
+    return [m.group(0) for m in SPECIFIER.finditer(text)]
+
+
+def source_value(key: str, entry: dict) -> str:
+    """The string the translations must stay compatible with."""
+    en = entry.get("localizations", {}).get("en", {}).get("stringUnit", {})
+    return en.get("value", key)
+
+
+def translatable(source: str) -> bool:
+    """False for keys that are only format specifiers or punctuation."""
+    return any(char.isalpha() for char in SPECIFIER.sub("", source))
+
+
+def check_catalog(path: Path, languages: list[str]) -> tuple[list[str], list[str]]:
+    problems: list[str] = []
+    skipped: list[str] = []
+    try:
+        catalog = json.loads(path.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError) as exc:
+        return [f"{path}: unreadable or invalid JSON ({exc})"], skipped
+
+    if not isinstance(catalog.get("strings"), dict):
+        return [f"{path}: missing top-level 'strings' object"], skipped
+
+    for key, entry in sorted(catalog["strings"].items()):
+        localizations = entry.get("localizations", {})
+        source = source_value(key, entry)
+        expected = specifiers(source)
+
+        if not translatable(source):
+            skipped.append(f"{path}: nothing to translate in {key!r}")
+            continue
+
+        for language in languages:
+            unit = localizations.get(language, {}).get("stringUnit", {})
+            value = unit.get("value")
+            if value is None:
+                problems.append(f"{path}: [{language}] missing translation for {key!r}")
+                continue
+            found = specifiers(value)
+            if found != expected:
+                problems.append(
+                    f"{path}: [{language}] format specifiers differ for {key!r}: "
+                    f"source {expected} vs translation {found}"
+                )
+
+    return problems, skipped
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("catalogs", nargs="*", default=list(DEFAULT_CATALOGS))
+    parser.add_argument("--languages", nargs="+", default=["es"])
+    args = parser.parse_args()
+
+    root = Path(__file__).resolve().parent.parent
+    problems: list[str] = []
+    skipped: list[str] = []
+    checked = 0
+
+    for name in args.catalogs or DEFAULT_CATALOGS:
+        path = Path(name)
+        if not path.is_absolute():
+            path = root / path
+        catalog_problems, catalog_skipped = check_catalog(path, args.languages)
+        problems.extend(catalog_problems)
+        skipped.extend(catalog_skipped)
+        checked += 1
+
+    for entry in skipped:
+        print(f"skipped: {entry}")
+
+    if problems:
+        for problem in problems:
+            print(problem)
+        print(f"\n{len(problems)} problem(s) in {checked} catalog(s).")
+        return 1
+
+    print(
+        f"OK: {checked} catalog(s) valid, every translatable key rendered in "
+        f"{', '.join(args.languages)} with matching format specifiers "
+        f"({len(skipped)} key(s) skipped as non-translatable)."
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
## Summary

Adds a complete **Latin American Spanish (`es`)** localization for both the main app and the FinderSync extension, and makes the last few user-visible hardcoded strings localizable so they can be translated at all.

- `RClick/Localizable.xcstrings`: **156** Spanish strings
- `FinderSyncExt/Localizable.xcstrings`: **143** Spanish strings
- 164 unique strings overall; `es` registered in `knownRegions`

English remains the source language and the fallback for unsupported system languages. No existing `en`, `ja` or `zh-Hans` entry was modified — the catalog diff is additive only (verified key by key).

### Strings that were not localizable before

| Location | Was | Now |
|---|---|---|
| `FinderSyncExt.toolbarItemToolTip` | hardcoded English | `AppLocalization.localized("RClick: Click for menu options")` |
| `Updater.downloadAsset` | hardcoded `"下载失败"`, shown to the user through `UpdateView.errorView` | key `Download failed` |
| `Updater.extractAppZip` | hardcoded `"未知错误"`, interpolated into the visible `Extraction failed: %@` | key `Unknown error` |

Six keys the UI already referenced were missing from `RClick/Localizable.xcstrings` and silently fell back to the literal (`OK`, `Save`, `Add`, `Display Name`, `Default Open App`, `Edit App Properties`). They are now present, reusing the `zh-Hans`/`ja` values that already existed in the extension's catalog. Every newly introduced key ships `en`, `es`, `zh-Hans` and `ja`, so no language regresses.

### Seed data

`ActionEntity.createDefaultActions()` and `CommonDirEntity.createDefaultCommonDirs()` stored hardcoded Chinese names (`复制路径`, `桌面`, …). The UI never showed them — `RCAction.displayName` and `CommonDir.displayName` resolve by `id` — but they were the persisted values and an incorrect English fallback. They now use the English source keys, matching `RCAction.all`. No `id`, ordering or behavior change.

### Tooling

`scripts/check-localization.py` validates both catalogs: JSON well-formedness, translation coverage per language, and that every translation preserves the source format specifiers **in the same order** (`%@`, `%1$@`, `%lld`, …). It is a standalone script, not part of any target.

```
$ python3 scripts/check-localization.py
OK: 2 catalog(s) valid, every translatable key rendered in es with matching
format specifiers (4 key(s) skipped as non-translatable).
```

The four skipped keys are bare placeholders with no text (`""`, `%@`, `%lld`, `%@（%@）`).

## Type of Change

- [ ] 🐛 Bug fix
- [x] ✨ New feature
- [ ] 📝 Documentation update
- [ ] ♻️ Refactoring
- [ ] ⚡ Performance improvement
- [ ] 🔧 Build/CI change
- [ ] 🧪 Test addition/update

## Related Issue

None.

## Screenshots

The layout is unchanged; only string values differ. Verified on screen with the Settings window in Spanish across all six tabs (General, Apps, Acciones, Nuevo archivo, Carpetas frecuentes, Acerca de).

One pre-existing cosmetic note: the sidebar truncates long labels (`Common F…` in English today). Spanish has two truncated entries instead of one (`Nuevo archi…`, `Carpetas fr…`). This is the fixed `navigationSplitViewColumnWidth(220)`, not a translation length problem — happy to widen it in a separate PR if you want.

Reviewers can check any language without changing system settings:

```bash
/path/to/RClick.app/Contents/MacOS/RClick -AppleLanguages "(es-419)"
```

## Testing

Environment: macOS 26.6 (arm64), Xcode 26.6 (17F113).

### Manual Testing

- [x] App launches and appears in menu bar
- [ ] Right-click menu works correctly in Finder — **not verified**, see note below
- [x] Dark mode looks correct (verified in dark mode; light mode not checked)
- [x] Settings persist across restarts
- [ ] FinderSync extension loads properly — **not verified**, see note below

I have no code-signing identity available, so the FinderSync extension cannot be enabled on my machine and the context menu could not be exercised at runtime. What I did verify instead: the compiled `FinderSyncExt.appex` ships `es.lproj/Localizable.strings` with all 143 strings, alongside `en`, `ja` and `zh-Hans`. The action labels resolve through `RCAction.displayName` in the host app before being sent to the extension, and those keys are covered.

### Build Verification

```
$ xcodebuild -project RClick.xcodeproj -scheme RClick -configuration Debug \
    -destination 'platform=macOS,arch=arm64' CODE_SIGNING_ALLOWED=NO clean build -quiet
EXIT=0   (no new warnings; the two pre-existing `no 'async' operations occur within
          'await' expression` warnings in BookmarkManager.swift are untouched)

$ xcodebuild -project RClick.xcodeproj -scheme RClick -configuration Debug \
    -destination 'platform=macOS,arch=arm64' CODE_SIGNING_ALLOWED=NO test -quiet
EXIT=0
Test suite 'RClickTests' started on 'My Mac'
Test case 'RClickTests/example()' passed (0.000 seconds)

$ xcrun xcstringstool compile RClick/Localizable.xcstrings         # exit 0
$ xcrun xcstringstool compile FinderSyncExt/Localizable.xcstrings  # exit 0
```

Both bundles were inspected after building: `RClick.app` and the embedded `.appex` each contain `en.lproj`, `es.lproj`, `ja.lproj` and `zh-Hans.lproj`.

## Checklist

- [x] My code follows the project's Swift 6.2 conventions (see CONTRIBUTING.md)
- [x] All UI is SwiftUI (no AppKit UI components)
- [x] I have tested on macOS 15.6+ (macOS 26.6)
- [ ] I have tested with both light and dark mode — dark mode only
- [x] I have updated documentation if needed (no doc change required; README already documents how to add a language)
- [x] My branch is up-to-date with `dev`

## Additional Notes

- Terminology follows Apple's Spanish localization: *Finder*, *Ajustes del Sistema*, *Accesibilidad*, *Acceso total al disco*, *Aplicaciones*, *Papelera*. Product names, formats and file extensions are left untouched (RClick, AirDrop, SF Symbol, `.pptx`, `.numbers`, …).
- No changes to logic, architecture, entitlements, bundle identifiers, signing or build configuration. The only `project.pbxproj` change is the single `es` entry in `knownRegions`.
- The repository docs list three supported languages; I left those tables alone to keep this diff focused, but I'm glad to add Spanish to them if you'd prefer it in the same PR.
